### PR TITLE
inspect-lesson-plan: carry over no-video-in-combination message from lesson-plan-resource-details

### DIFF
--- a/shiksha-website/shiksha-frontend/src/app/shared/components/lesson-plan-resource-details/lesson-plan-resource-details.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/shared/components/lesson-plan-resource-details/lesson-plan-resource-details.component.ts
@@ -677,7 +677,6 @@ export class LessonPlanResourceDetailsComponent implements OnInit, OnDestroy {
 
   confirm(value: string) {
     if (value === 'ok') {
-      //this.lessonForm.get('videos')?.setValue(false);
       this.on_form_submit();
     }
     this.showConfirmPopup = false;

--- a/shiksha-website/shiksha-frontend/src/app/shared/components/lesson-plan-resource-details/lesson-plan-resource-details.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/shared/components/lesson-plan-resource-details/lesson-plan-resource-details.component.ts
@@ -548,7 +548,7 @@ export class LessonPlanResourceDetailsComponent implements OnInit, OnDestroy {
       let params = new HttpParams();
       params = params.append(
         'filters[includeVideos]',
-        this.lessonForm.get('videos')?.value
+        !this.showConfirmPopup && this.lessonForm.get('videos')?.value
       );
       params = params.append(
         'filters[levels]',
@@ -677,31 +677,8 @@ export class LessonPlanResourceDetailsComponent implements OnInit, OnDestroy {
 
   confirm(value: string) {
     if (value === 'ok') {
-      // retain videos=true in formfiltervalues
-      const comprehensionLevel = this.checkboxOptions
-        .filter((opt) => opt.checked)
-        .map((val) => val.value);
-      let params = new HttpParams();
-      params = params.append(
-        'filters[includeVideos]',
-        'false'  // get the lesson plan without the error
-      );
-      params = params.append(
-        'filters[levels]',
-        JSON.stringify(comprehensionLevel)
-      );
-      // call api with videos=false to get lesson plan
-      this.contentGenService.getLessonPlanDetails(this.planId, params)
-        .subscribe({
-          next: (val: any) => {
-            this.contentGenService.selectedLessonPlan = val.data[0];
-            this.isGenerate = true;
-            this.router.navigate([this.getLessonType()?.inspectUrl]);
-          },
-          error: (err) => {
-            this.utilityservice.handleError(err);
-          },
-        });
+      //this.lessonForm.get('videos')?.setValue(false);
+      this.on_form_submit();
     }
     this.showConfirmPopup = false;
   }

--- a/shiksha-website/shiksha-frontend/src/app/shared/components/lesson-plan-resource-details/lesson-plan-resource-details.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/shared/components/lesson-plan-resource-details/lesson-plan-resource-details.component.ts
@@ -568,6 +568,7 @@ export class LessonPlanResourceDetailsComponent implements OnInit, OnDestroy {
           },
           error: (err) => {
             if (err?.error?.message === 'Video not found!') {
+              this.contentGenService.formfiltervalues = formvalues;
               this.showConfirmPopup = true;
             } else if (err?.error?.message === 'Draft Exists') {
               this.showDraftPopup = true;
@@ -676,8 +677,31 @@ export class LessonPlanResourceDetailsComponent implements OnInit, OnDestroy {
 
   confirm(value: string) {
     if (value === 'ok') {
-      this.lessonForm.get('videos')?.setValue(false);
-      this.on_form_submit();
+      // retain videos=true in formfiltervalues
+      const comprehensionLevel = this.checkboxOptions
+        .filter((opt) => opt.checked)
+        .map((val) => val.value);
+      let params = new HttpParams();
+      params = params.append(
+        'filters[includeVideos]',
+        'false'  // get the lesson plan without the error
+      );
+      params = params.append(
+        'filters[levels]',
+        JSON.stringify(comprehensionLevel)
+      );
+      // call api with videos=false to get lesson plan
+      this.contentGenService.getLessonPlanDetails(this.planId, params)
+        .subscribe({
+          next: (val: any) => {
+            this.contentGenService.selectedLessonPlan = val.data[0];
+            this.isGenerate = true;
+            this.router.navigate([this.getLessonType()?.inspectUrl]);
+          },
+          error: (err) => {
+            this.utilityservice.handleError(err);
+          },
+        });
     }
     this.showConfirmPopup = false;
   }

--- a/shiksha-website/shiksha-frontend/src/app/view/user/content-generation/inspect-lesson-plan/inspect-lesson-plan.component.html
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/content-generation/inspect-lesson-plan/inspect-lesson-plan.component.html
@@ -344,10 +344,13 @@
         </div>
       </div>     
 
-      <ng-container *ngIf="videoUrls.length">
+      <ng-container *ngIf="isVideoSelected">
       <h3 class="text-base text-content font-semibold" >{{'Videos' | translate}}</h3>
       <div class="border border-shade-100 text-content rounded mb-5 p-4 bg-white  overflow-x-auto">
         <div class="flex gap-4">
+          <div *ngIf="videoUrls.length === 0" class="w-full text-center p-4">
+            <p class="text-content-60">{{'Selected combination does not include videos.' | translate}}</p>
+          </div>
           <div *ngFor="let video of videoUrls" class="min-w-[416px] min-h-[190px]">
             <div class=" bg-white border">
               <div class="bg-shade-80 p-3 rounded">

--- a/shiksha-website/shiksha-frontend/src/app/view/user/content-generation/inspect-lesson-plan/inspect-lesson-plan.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/content-generation/inspect-lesson-plan/inspect-lesson-plan.component.ts
@@ -148,6 +148,8 @@ export class InspectLessonPlanComponent implements OnInit, OnDestroy {
 
   regenerationLimitReached = false;
 
+  isVideoSelected: boolean = false;
+
 
   unloadHandler = (event: BeforeUnloadEvent) => {
     event.preventDefault();
@@ -229,7 +231,9 @@ export class InspectLessonPlanComponent implements OnInit, OnDestroy {
     {
       return {title:e.title, link:this.utilityService.trustUrl(e.url)}
     })
-    
+      if(this.contentGenService.formfiltervalues && this.contentGenService.formfiltervalues.videos !== undefined) {
+        this.isVideoSelected = this.contentGenService.formfiltervalues.videos === true;
+      }
     }
   }
 
@@ -270,6 +274,9 @@ export class InspectLessonPlanComponent implements OnInit, OnDestroy {
         {
           return {title:e.title, link:this.utilityService.trustUrl(e.url)}
         })
+        if(res.data.isVideoSelected !== undefined) {
+          this.isVideoSelected = res.data.isVideoSelected;
+        }
       },
       error: (err) => {
         this.utilityService.handleError(err);
@@ -415,7 +422,7 @@ export class InspectLessonPlanComponent implements OnInit, OnDestroy {
       lessonId,
       instructionSet: this.tabs,
       learningOutcomes: this.learningOutcomes,
-      isVideoSelected:this.videoUrls.length ? true : false
+      isVideoSelected: this.isVideoSelected
     };
 
     forkJoin([

--- a/shiksha-website/shiksha-frontend/src/assets/i18n/en.json
+++ b/shiksha-website/shiksha-frontend/src/assets/i18n/en.json
@@ -247,6 +247,7 @@
   "Are you sure you want to delete this Schedule?" : "Are you sure you want to delete this Schedule?",
   "Ok" : "Ok",
   "Confirm" : "Confirm",
+  "Selected combination does not include videos." : "Selected combination does not include videos.",
   "Selected combination does not include videos. Do you want to continue ?" : "Selected combination does not include videos. Do you want to continue ?",
   "Do you want to logout?" : "Do you want to logout?",
   "School List" : "School List",

--- a/shiksha-website/shiksha-frontend/src/assets/i18n/kn.json
+++ b/shiksha-website/shiksha-frontend/src/assets/i18n/kn.json
@@ -243,6 +243,7 @@
   "Are you sure you want to delete this Schedule?" : "ಈ ವೇಳಾಪಟ್ಟಿಯನ್ನು ಅಳಿಸಲು ನೀವು ಖಚಿತವಾಗಿ ಬಯಸುವಿರಾ?",
   "Ok" : "ಸರಿ",
   "Confirm" : "ದೃಢೀಕರಿಸಿ",
+  "Selected combination does not include videos." : "ಆಯ್ಕೆಮಾಡಿದ ಸಂಯೋಜನೆಯು ವೀಡಿಯೊಗಳನ್ನು ಒಳಗೊಂಡಿಲ್ಲ.",
   "Selected combination does not include videos. Do you want to continue ?" : "ಆಯ್ಕೆಮಾಡಿದ ಸಂಯೋಜನೆಯು ವೀಡಿಯೊಗಳನ್ನು ಒಳಗೊಂಡಿಲ್ಲ. ನೀವು ಮುಂದುವರಿಸಲು ಬಯಸುತ್ತೀರಾ ?",
   "Do you want to logout?" : "ನೀವು ಲಾಗ್ಔಟ್ ಮಾಡಲು ಬಯಸುವಿರಾ?",
   "Reason required":"ಕಾರಣ ಅಗತ್ಯವಿದೆ",


### PR DESCRIPTION
## Introduction
"Selected combination does not include videos." message is now carried over to the inspect lesson plan screen so users get a clear heads-up when their selected lesson plan combo (Chapter, Sub-Topic) does not include videos.

This new message is visible in both places - inspection (i.e., /user/content-generation/inspect-lesson-plan), and post generation (e.g., /user/content-generation/lesson-plan/68fd02dec09fd73c88ce5f4b).

## Changes
'Videos' section in /user/content-generation/lesson-plan is no longer hidden when user selects 'Yes' for a selection with no videos.
- Include Videos=Yes, selection has videos → Show 'Videos' box with videos in selection (existing behavior)
- Include Videos=Yes, selection has no videos → Show 'Videos' box with "Selected combination does not include videos." (new behavior)
- Include Videos=No, * → Do not show 'Videos' box (existing behavior)

## Resources
<img alt="image" src="https://github.com/user-attachments/assets/e5ba2cc2-868a-4911-b686-ac3c34758441" />
<div align="center">
  Modal shown to users when the combination does not include Video (Existing UI)
</div>

<img alt="image" src="https://github.com/user-attachments/assets/ef6815f4-9368-49e4-95e7-8d5537de6926" />
<div align="center">
  'Documents' tab on the next screen no longer hides Videos box and alerts users again about their combination (New UI).
</div>