### PR TITLE
shiksha-ingestion: code enhancements

### DIFF
--- a/components/ingestion-pipeline-mineru/src/mineru_extractor/__init__.py
+++ b/components/ingestion-pipeline-mineru/src/mineru_extractor/__init__.py
@@ -10,15 +10,14 @@ import os
 import tempfile
 import shutil
 import logging
-from typing import List
 
 # Configure logging
 logger = logging.getLogger(__name__)
+from ingestion_pipeline.utils.pdfutils import convert_pdf_to_images
 from magic_pdf.data.data_reader_writer import FileBasedDataWriter, FileBasedDataReader
 from magic_pdf.data.dataset import PymuDocDataset
 from magic_pdf.model.doc_analyze_by_custom_model import doc_analyze
 from magic_pdf.data.read_api import read_local_images
-from pdf2image import convert_from_path
 
 from ingestion_pipeline.base.text_extractor import TextExtractor
 
@@ -177,12 +176,11 @@ class MinerUTextExtractor(TextExtractor):
         # Ensure the output directory exists
         os.makedirs(output_dir, exist_ok=True)
         
-        # Convert PDF pages to images using pdf2image library
-        images = convert_from_path(file_path, dpi=dpi)
-        
-        # Save each page as an image with the format {page_index}.jpg
-        for i, image in enumerate(images):
-            image_path = os.path.join(output_dir, f"{i}.jpg")
-            image.save(image_path, "JPEG")
+        # Convert PDF pages to images
+        with convert_pdf_to_images(file_path, dpi=dpi) as images:
+            # Save each page as an image with the format {page_index}.jpg
+            for i, image in enumerate(images):
+                image_path = os.path.join(output_dir, f"{i}.jpg")
+                image.save(image_path, "JPEG")
             
         return output_dir

--- a/components/ingestion-pipeline-smoldocling/src/smoldocling_extractor/__init__.py
+++ b/components/ingestion-pipeline-smoldocling/src/smoldocling_extractor/__init__.py
@@ -1,5 +1,5 @@
 import logging
-from pdf2image import convert_from_path
+from ingestion_pipeline.utils.pdfutils import convert_pdf_to_images
 import torch
 from docling_core.types.doc import DoclingDocument
 from docling_core.types.doc.document import DocTagsDocument
@@ -33,39 +33,39 @@ class SmolDoclingTextExtractor(TextExtractor):
          4. Combining all page outputs into one markdown string.
         """
         # Convert PDF pages to images; adjust dpi as needed
-        pages = convert_from_path(file_path, dpi=200)
-        markdown_outputs = []
-        
-        for idx, page in enumerate(pages):
-            self.logger.debug(f"PAGE EXTRACTION TAKING PLACE {idx + 1}")
-            # Create the chat message prompt for the page
-            messages = [
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "image"},
-                        {"type": "text", "text": "Convert this page to docling."}
-                    ]
-                }
-            ]
-            prompt = self.processor.apply_chat_template(messages, add_generation_prompt=True)
-            inputs = self.processor(text=prompt, images=[page], return_tensors="pt")
-            inputs = inputs.to(self.device)
+        with convert_pdf_to_images(file_path, dpi=200) as pages:
+            markdown_outputs = []
             
-            # Generate the output from the model
-            generated_ids = self.model.generate(**inputs, max_new_tokens=8192)
-            prompt_length = inputs.input_ids.shape[1]
-            trimmed_generated_ids = generated_ids[:, prompt_length:]
-            
-            # Decode the model output
-            doctags = self.processor.batch_decode(trimmed_generated_ids, skip_special_tokens=False)[0].lstrip()
-            
-            # Convert the output to a DocTagsDocument and then to a DoclingDocument
-            doctags_doc = DocTagsDocument.from_doctags_and_image_pairs([doctags], [page])
-            doc = DoclingDocument(name="Document")
-            doc.load_from_doctags(doctags_doc)
-            markdown = doc.export_to_markdown()
-            markdown_outputs.append(markdown)
+            for idx, page in enumerate(pages):
+                self.logger.debug(f"PAGE EXTRACTION TAKING PLACE {idx + 1}")
+                # Create the chat message prompt for the page
+                messages = [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "image"},
+                            {"type": "text", "text": "Convert this page to docling."}
+                        ]
+                    }
+                ]
+                prompt = self.processor.apply_chat_template(messages, add_generation_prompt=True)
+                inputs = self.processor(text=prompt, images=[page], return_tensors="pt")
+                inputs = inputs.to(self.device)
+                
+                # Generate the output from the model
+                generated_ids = self.model.generate(**inputs, max_new_tokens=8192)
+                prompt_length = inputs.input_ids.shape[1]
+                trimmed_generated_ids = generated_ids[:, prompt_length:]
+                
+                # Decode the model output
+                doctags = self.processor.batch_decode(trimmed_generated_ids, skip_special_tokens=False)[0].lstrip()
+                
+                # Convert the output to a DocTagsDocument and then to a DoclingDocument
+                doctags_doc = DocTagsDocument.from_doctags_and_image_pairs([doctags], [page])
+                doc = DoclingDocument(name="Document")
+                doc.load_from_doctags(doctags_doc)
+                markdown = doc.export_to_markdown()
+                markdown_outputs.append(markdown)
         
         # Combine the markdown output of all pages into one string
         return "\n\n".join(markdown_outputs)

--- a/components/ingestion-pipeline/src/ingestion_pipeline/text_extractors/llm_extractor.py
+++ b/components/ingestion-pipeline/src/ingestion_pipeline/text_extractors/llm_extractor.py
@@ -1,13 +1,12 @@
 import base64
 import io
 import logging
-from typing import List, Dict, Any, Optional
-import os
+from typing import List, Optional
 
-from pdf2image import convert_from_path
 from PIL import Image
 from litellm import completion
 from ingestion_pipeline.base.text_extractor import TextExtractor
+from ingestion_pipeline.utils.pdfutils import convert_pdf_to_images
 
 
 class LLMTextExtractor(TextExtractor):
@@ -314,11 +313,10 @@ Output ONLY the transcribed markdown content for the current image. Do NOT wrap 
         # Convert PDF to images
         dpi = kwargs.get("dpi", 300)  # Higher DPI for better quality
         self.logger.info(f"Converting PDF to images with DPI {dpi}: {file_path}")
-        images = convert_from_path(file_path, dpi=dpi)
-
-        # Process pages in batches with context from previous pages
-        return self._process_pages_in_batches(
-            images,
-            batch_size=batch_size,
-            document_structure_hint=document_structure_hint,
-        )
+        with convert_pdf_to_images(file_path, dpi=dpi) as images:
+            # Process pages in batches with context from previous pages
+            return self._process_pages_in_batches(
+                images,
+                batch_size=batch_size,
+                document_structure_hint=document_structure_hint,
+            )

--- a/components/ingestion-pipeline/src/ingestion_pipeline/text_extractors/llm_json_extractor.py
+++ b/components/ingestion-pipeline/src/ingestion_pipeline/text_extractors/llm_json_extractor.py
@@ -2,13 +2,12 @@ import base64
 import io
 import json
 import logging
-from typing import List, Dict, Any, Optional
-import os
+from typing import List, Dict, Optional
 
-from pdf2image import convert_from_path
 from PIL import Image
 from litellm import completion
 from ingestion_pipeline.base.text_extractor import TextExtractor
+from ingestion_pipeline.utils.pdfutils import convert_pdf_to_images
 
 
 class LLMJSONExtractor(TextExtractor):
@@ -362,14 +361,13 @@ Do NOT wrap the output in any code block or add any extra commentary. The output
         # Convert PDF to images
         dpi = kwargs.get("dpi", 300)  # Higher DPI for better quality
         self.logger.info(f"Converting PDF to images with DPI {dpi}: {file_path}")
-        images = convert_from_path(file_path, dpi=dpi)
-
-        # Process pages in batches with context from previous pages
-        all_sections = self._process_pages_in_batches(
-            images,
-            batch_size=batch_size,
-            document_structure_hint=document_structure_hint,
-        )
+        with convert_pdf_to_images(file_path, dpi=dpi) as images:
+            # Process pages in batches with context from previous pages
+            all_sections = self._process_pages_in_batches(
+                images,
+                batch_size=batch_size,
+                document_structure_hint=document_structure_hint,
+            )
 
         # Return as JSON string
         return json.dumps(all_sections, indent=2, ensure_ascii=False)

--- a/components/ingestion-pipeline/src/ingestion_pipeline/text_extractors/tesseract_ocr.py
+++ b/components/ingestion-pipeline/src/ingestion_pipeline/text_extractors/tesseract_ocr.py
@@ -1,6 +1,6 @@
 import pytesseract
-from pdf2image import convert_from_path
 from ingestion_pipeline.base.text_extractor import TextExtractor
+from ingestion_pipeline.utils.pdfutils import convert_pdf_to_images
 
 class TesseractTextExtractor(TextExtractor):
     def extract_text(self, file_path: str, **kwargs) -> str:
@@ -19,26 +19,26 @@ class TesseractTextExtractor(TextExtractor):
             str: The combined extracted text from the PDF.
         """
         two_columns = kwargs.get("two_columns", False)
-        # Convert PDF pages to a list of PIL images.
-        images = convert_from_path(file_path)
-        full_text = ""
 
-        for image in images:
-            if two_columns:
-                width, height = image.size
-                # Define the bounding boxes for left and right halves.
-                left_box = (0, 0, width // 2, height)
-                right_box = (width // 2, 0, width, height)
-                # Crop the image for each column.
-                left_image = image.crop(left_box)
-                right_image = image.crop(right_box)
-                # Extract text from each column.
-                left_text = pytesseract.image_to_string(left_image)
-                right_text = pytesseract.image_to_string(right_image)
-                page_text = left_text + "\n" + right_text
-            else:
-                page_text = pytesseract.image_to_string(image)
-            
-            full_text += page_text + "\n"
+        # Convert PDF pages to a list of PIL images.
+        full_text = ""
+        with convert_pdf_to_images(file_path) as images:
+            for image in images:
+                if two_columns:
+                    width, height = image.size
+                    # Define the bounding boxes for left and right halves.
+                    left_box = (0, 0, width // 2, height)
+                    right_box = (width // 2, 0, width, height)
+                    # Crop the image for each column.
+                    left_image = image.crop(left_box)
+                    right_image = image.crop(right_box)
+                    # Extract text from each column.
+                    left_text = pytesseract.image_to_string(left_image)
+                    right_text = pytesseract.image_to_string(right_image)
+                    page_text = left_text + "\n" + right_text
+                else:
+                    page_text = pytesseract.image_to_string(image)
+
+                full_text += page_text + "\n"
 
         return full_text

--- a/components/ingestion-pipeline/src/ingestion_pipeline/utils/pdfutils.py
+++ b/components/ingestion-pipeline/src/ingestion_pipeline/utils/pdfutils.py
@@ -1,0 +1,12 @@
+from contextlib import contextmanager
+import os
+import tempfile
+from typing import Generator, List
+from pdf2image import convert_from_path
+from PIL import Image
+
+@contextmanager
+def convert_pdf_to_images(pdf_file, **kwargs) -> Generator[List[Image.Image], None, None]:
+    """Convert pdf2image pages and store them in disk (temp) instead of piling up in RAM."""
+    with tempfile.TemporaryDirectory() as tempdir:
+        yield convert_from_path(pdf_file, output_folder=tempdir, thread_count=min(4, os.cpu_count() or 4), **kwargs)

--- a/components/ingestion-pipeline/src/ingestion_pipeline/utils/toc_extractor.py
+++ b/components/ingestion-pipeline/src/ingestion_pipeline/utils/toc_extractor.py
@@ -2,13 +2,12 @@ import base64
 import io
 import json
 import logging
-from typing import List, Optional, Dict, Any, Union
-import os
+from typing import List, Optional
 
-from pdf2image import convert_from_path
 from PIL import Image
 from litellm import completion
-from ingestion_pipeline.base.data_model import TableOfContent, Section, PageRange
+from ingestion_pipeline.base.data_model import TableOfContent
+from ingestion_pipeline.utils.pdfutils import convert_pdf_to_images
 
 
 class TableOfContentsExtractor:
@@ -227,21 +226,20 @@ Notes:
         # Convert PDF to images
         dpi = kwargs.get("dpi", 200)  # Lower DPI is sufficient for TOC extraction
         self.logger.info(f"Converting PDF to images with DPI {dpi}: {file_path}")
-        images = convert_from_path(file_path, dpi=dpi)
-        
-        # Process page range
-        processed_page_range = None
-        if page_range:
-            start_page, end_page = page_range
-            if start_page > 0 and end_page >= start_page and end_page <= len(images):
-                processed_page_range = list(range(start_page, end_page + 1))
-            else:
-                raise ValueError(f"Invalid page_range: {page_range}. start_page must be > 0, end_page must be >= start_page and <= {len(images)}")
-        
-        # Process TOC pages with LLM
-        return self._process_toc_pages_with_llm(
-            images, 
-            page_range=processed_page_range,
-            total_document_pages=len(images),
-            document_specific_hint=document_specific_hint
-        )
+        with convert_pdf_to_images(file_path, dpi=dpi) as images:
+            # Process page range
+            processed_page_range = None
+            if page_range:
+                start_page, end_page = page_range
+                if start_page > 0 and end_page >= start_page and end_page <= len(images):
+                    processed_page_range = list(range(start_page, end_page + 1))
+                else:
+                    raise ValueError(f"Invalid page_range: {page_range}. start_page must be > 0, end_page must be >= start_page and <= {len(images)}")
+
+            # Process TOC pages with LLM
+            return self._process_toc_pages_with_llm(
+                images, 
+                page_range=processed_page_range,
+                total_document_pages=len(images),
+                document_specific_hint=document_specific_hint
+            )

--- a/components/ingestion-pipeline/src/ingestion_pipeline/utils/toc_page_finder.py
+++ b/components/ingestion-pipeline/src/ingestion_pipeline/utils/toc_page_finder.py
@@ -1,12 +1,12 @@
 import base64
 import io
 import logging
-from typing import List, Dict, Any, Optional, Tuple
-import os
+from typing import List, Optional, Tuple
 
-from pdf2image import convert_from_path
 from PIL import Image
 from litellm import completion
+
+from ingestion_pipeline.utils.pdfutils import convert_pdf_to_images
 
 
 class TOCPageFinder:
@@ -219,72 +219,66 @@ Respond ONLY with the JSON array of boolean values, no additional text or explan
         # Convert PDF to images (only the pages we need to check)
         dpi = kwargs.get("dpi", 200)  # Lower DPI for faster processing
         self.logger.info(f"Converting first {max_pages_to_check} pages to images with DPI {dpi}: {file_path}")
-        
-        try:
-            # Convert only the pages we need to check
-            images = convert_from_path(
-                file_path, 
-                dpi=dpi, 
-                first_page=1, 
-                last_page=max_pages_to_check
-            )
-        except Exception as e:
-            self.logger.error(f"Error converting PDF to images: {e}")
-            return [], f"Error converting PDF: {str(e)}"
-
-        total_pages = len(images)
-        total_batches = (total_pages + batch_size - 1) // batch_size
-        
-        self.logger.info(f"Analyzing {total_pages} pages in {total_batches} batches of {batch_size}")
 
         # Track results for each page
         page_results = []  # List of (page_number, is_toc) tuples
         analysis_summary = []
-        
-        # Track state for early stopping
-        first_true_found = False
-        toc_complete = False
-        
-        # Process pages in batches
-        for batch_idx in range(total_batches):
-            start_idx = batch_idx * batch_size
-            end_idx = min(start_idx + batch_size, total_pages)
-            batch_images = images[start_idx:end_idx]
-            start_page = start_idx + 1  # 1-indexed
-            
-            self.logger.info(f"Processing batch {batch_idx + 1}/{total_batches} (pages {start_page}-{start_page + len(batch_images) - 1})")
-            
-            # Analyze this batch
-            batch_results = self._analyze_batch_with_llm(
-                batch_images,
-                start_page,
-                batch_idx + 1,
-                total_batches
-            )
-            
-            # Store results for each page in this batch and check for early stopping
-            for i, is_toc in enumerate(batch_results):
-                page_num = start_page + i
-                page_results.append((page_num, is_toc))
+        try:
+            # Convert only the pages we need to check
+            with convert_pdf_to_images(file_path, dpi=dpi, first_page=1, last_page=max_pages_to_check) as images:
+                total_pages = len(images)
+                total_batches = (total_pages + batch_size - 1) // batch_size
                 
-                # Check for early stopping condition
-                if is_toc and not first_true_found:
-                    # Found the first True
-                    first_true_found = True
-                elif not is_toc and first_true_found:
-                    # Found the first False after True - we can stop
-                    toc_complete = True
-                    self.logger.info(f"Found first False after True at page {page_num}. Stopping analysis.")
-                    break
-            
-            analysis_summary.append(
-                f"Batch {batch_idx + 1} (pages {start_page}-{start_page + len(batch_images) - 1}): "
-                f"{batch_results}"
-            )
-            
-            # Exit the batch loop if we've completed TOC detection
-            if toc_complete:
-                break
+                self.logger.info(f"Analyzing {total_pages} pages in {total_batches} batches of {batch_size}")
+                
+                # Track state for early stopping
+                first_true_found = False
+                toc_complete = False
+                
+                # Process pages in batches
+                for batch_idx in range(total_batches):
+                    start_idx = batch_idx * batch_size
+                    end_idx = min(start_idx + batch_size, total_pages)
+                    batch_images = images[start_idx:end_idx]
+                    start_page = start_idx + 1  # 1-indexed
+                    
+                    self.logger.info(f"Processing batch {batch_idx + 1}/{total_batches} (pages {start_page}-{start_page + len(batch_images) - 1})")
+                    
+                    # Analyze this batch
+                    batch_results = self._analyze_batch_with_llm(
+                        batch_images,
+                        start_page,
+                        batch_idx + 1,
+                        total_batches
+                    )
+                    
+                    # Store results for each page in this batch and check for early stopping
+                    for i, is_toc in enumerate(batch_results):
+                        page_num = start_page + i
+                        page_results.append((page_num, is_toc))
+                        
+                        # Check for early stopping condition
+                        if is_toc and not first_true_found:
+                            # Found the first True
+                            first_true_found = True
+                        elif not is_toc and first_true_found:
+                            # Found the first False after True - we can stop
+                            toc_complete = True
+                            self.logger.info(f"Found first False after True at page {page_num}. Stopping analysis.")
+                            break
+                    
+                    analysis_summary.append(
+                        f"Batch {batch_idx + 1} (pages {start_page}-{start_page + len(batch_images) - 1}): "
+                        f"{batch_results}"
+                    )
+                    
+                    # Exit the batch loop if we've completed TOC detection
+                    if toc_complete:
+                        break
+        except Exception as e:
+            self.logger.error(f"Error converting PDF to images: {e}")
+            return [], f"Error converting PDF: {str(e)}"
+
 
         # Find consecutive TOC pages starting from the first True
         toc_pages = []
@@ -310,7 +304,6 @@ Respond ONLY with the JSON array of boolean values, no additional text or explan
             final_summary += "\n\nNo table of contents found in the analyzed pages."
 
         self.logger.info(f"TOC analysis complete. Found TOC on pages: {toc_pages}")
-        
         return toc_pages, final_summary
 
     def get_toc_page_range(self, file_path: str, **kwargs) -> Tuple[Optional[int], Optional[int], str]:

--- a/components/translation/data_collection/pdf2img.py
+++ b/components/translation/data_collection/pdf2img.py
@@ -1,6 +1,17 @@
+from contextlib import contextmanager
 import os
 import glob
+import tempfile
+from typing import Generator, List
 from pdf2image import convert_from_path
+from PIL import Image
+
+@contextmanager
+def convert_pdf_to_images(pdf_file, **kwargs) -> Generator[List[Image.Image]]:
+    """Convert pdf2image pages and store them in disk (temp) instead of piling up in RAM."""
+    with tempfile.TemporaryDirectory() as tempdir:
+        yield convert_from_path(pdf_file, output_folder=tempdir, thread_count=min(4, os.cpu_count() or 4), **kwargs)
+
 
 def convert_pdfs_to_images(pdf_files, output_folder):
     
@@ -8,18 +19,18 @@ def convert_pdfs_to_images(pdf_files, output_folder):
         print(pdf_file)
         # Get the name of the PDF file without the extension
         pdf_name = os.path.splitext(os.path.basename(pdf_file))[0]
-        
+
         # Create a subdirectory in the output folder with the name of the PDF
         pdf_output_folder = os.path.join(output_folder, pdf_name, "images")
         os.makedirs(pdf_output_folder, exist_ok=True)
-        
-        # Convert PDF to images
-        images = convert_from_path(pdf_file, dpi=300)  # Set DPI for high quality
-        
-        # Save images in the relevant subdir
-        for page_number, image in enumerate(images):
-            image.save(os.path.join(pdf_output_folder, f'{page_number}.jpg'), 'JPEG')
-        
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            # Convert PDF to images
+            images = convert_from_path(pdf_file, dpi=300, output_folder=tempdir, thread_count=min(4, os.cpu_count() or 4))  # Set DPI for high quality
+            # Save images in the relevant subdir
+            for page_number, image in enumerate(images):
+                image.save(os.path.join(pdf_output_folder, f'{page_number}.jpg'), 'JPEG')
+
         print(f'Converted {pdf_name}.pdf to images in {pdf_output_folder}')
 
 if __name__ == "__main__":

--- a/shiksha-ingestion/pipeline_runner.py
+++ b/shiksha-ingestion/pipeline_runner.py
@@ -69,9 +69,11 @@ def get_chapter_identifier(pdf_path: str) -> str:
 
 def main():
     # Set up working directory
-    initial_inputs = {
-        "pdf": "/home/kchourasia/ShikshaOSS/TelanganaBoardBooks/split_pdfs/grade6/math/1.pdf"
-    }
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--textbook", required=True, help="Path to the source textbook (PDF)")
+    args = parser.parse_args()
+
+    initial_inputs = {"pdf": args.textbook}
     # RUN ID: current datetime, in string format using datetime module
     from datetime import datetime
 

--- a/shiksha-ingestion/pipeline_runner.py
+++ b/shiksha-ingestion/pipeline_runner.py
@@ -58,6 +58,7 @@ def setup_registry() -> PipelineRegistry:
     registry.register_step(SubtopicChapterLOsExtractionStep)
     registry.register_step(SubtopicCleaningStep)
     registry.register_step(SubtopicWiseLOExtractionStep)
+    registry.register_step(CreateIndexStep)
 
     return registry
 

--- a/shiksha-ingestion/pipeline_steps/step_8_create_indexes.py
+++ b/shiksha-ingestion/pipeline_steps/step_8_create_indexes.py
@@ -1,11 +1,8 @@
-import json
 import logging
 import os
 import re
-from textwrap import dedent
-from typing import Dict, List, Any
+from typing import Dict
 from dotenv import load_dotenv
-from pydantic import BaseModel, Field
 from rag_wrapper.rag_ops.qdrant_rag_ops import QdrantRagOps
 from llama_index.llms.azure_openai import AzureOpenAI
 from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
@@ -84,8 +81,8 @@ class CreateIndexStep(BasePipelineStep):
         Returns:
             StepResult with status and output paths containing the index_filter
         """
+        markdown_file = input_paths["markdown"]
         try:
-            markdown_file = input_paths["markdown"]
             with open(markdown_file, "r", encoding="utf-8") as file:
                 markdown_content = file.read()
             pages = self._split_by_pages(markdown_content)
@@ -131,6 +128,6 @@ class CreateIndexStep(BasePipelineStep):
         
         except Exception as e:
             logger.error(f"Error processing markdown file {markdown_file}: {e}")
-            return StepResult(status=StepStatus.FAILED, error=str(e))
+            return StepResult(status=StepStatus.FAILED, error=e)
         
         

--- a/shiksha-ingestion/poetry.lock
+++ b/shiksha-ingestion/poetry.lock
@@ -1702,6 +1702,83 @@ files = [
 colorama = ">=0.4"
 
 [[package]]
+name = "grpcio"
+version = "1.76.0"
+description = "HTTP/2-based RPC framework"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "grpcio-1.76.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:65a20de41e85648e00305c1bb09a3598f840422e522277641145a32d42dcefcc"},
+    {file = "grpcio-1.76.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:40ad3afe81676fd9ec6d9d406eda00933f218038433980aa19d401490e46ecde"},
+    {file = "grpcio-1.76.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:035d90bc79eaa4bed83f524331d55e35820725c9fbb00ffa1904d5550ed7ede3"},
+    {file = "grpcio-1.76.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4215d3a102bd95e2e11b5395c78562967959824156af11fa93d18fdd18050990"},
+    {file = "grpcio-1.76.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:49ce47231818806067aea3324d4bf13825b658ad662d3b25fada0bdad9b8a6af"},
+    {file = "grpcio-1.76.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8cc3309d8e08fd79089e13ed4819d0af72aa935dd8f435a195fd152796752ff2"},
+    {file = "grpcio-1.76.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:971fd5a1d6e62e00d945423a567e42eb1fa678ba89072832185ca836a94daaa6"},
+    {file = "grpcio-1.76.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9d9adda641db7207e800a7f089068f6f645959f2df27e870ee81d44701dd9db3"},
+    {file = "grpcio-1.76.0-cp310-cp310-win32.whl", hash = "sha256:063065249d9e7e0782d03d2bca50787f53bd0fb89a67de9a7b521c4a01f1989b"},
+    {file = "grpcio-1.76.0-cp310-cp310-win_amd64.whl", hash = "sha256:a6ae758eb08088d36812dd5d9af7a9859c05b1e0f714470ea243694b49278e7b"},
+    {file = "grpcio-1.76.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:2e1743fbd7f5fa713a1b0a8ac8ebabf0ec980b5d8809ec358d488e273b9cf02a"},
+    {file = "grpcio-1.76.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:a8c2cf1209497cf659a667d7dea88985e834c24b7c3b605e6254cbb5076d985c"},
+    {file = "grpcio-1.76.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08caea849a9d3c71a542827d6df9d5a69067b0a1efbea8a855633ff5d9571465"},
+    {file = "grpcio-1.76.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f0e34c2079d47ae9f6188211db9e777c619a21d4faba6977774e8fa43b085e48"},
+    {file = "grpcio-1.76.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8843114c0cfce61b40ad48df65abcfc00d4dba82eae8718fab5352390848c5da"},
+    {file = "grpcio-1.76.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8eddfb4d203a237da6f3cc8a540dad0517d274b5a1e9e636fd8d2c79b5c1d397"},
+    {file = "grpcio-1.76.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:32483fe2aab2c3794101c2a159070584e5db11d0aa091b2c0ea9c4fc43d0d749"},
+    {file = "grpcio-1.76.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:dcfe41187da8992c5f40aa8c5ec086fa3672834d2be57a32384c08d5a05b4c00"},
+    {file = "grpcio-1.76.0-cp311-cp311-win32.whl", hash = "sha256:2107b0c024d1b35f4083f11245c0e23846ae64d02f40b2b226684840260ed054"},
+    {file = "grpcio-1.76.0-cp311-cp311-win_amd64.whl", hash = "sha256:522175aba7af9113c48ec10cc471b9b9bd4f6ceb36aeb4544a8e2c80ed9d252d"},
+    {file = "grpcio-1.76.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:81fd9652b37b36f16138611c7e884eb82e0cec137c40d3ef7c3f9b3ed00f6ed8"},
+    {file = "grpcio-1.76.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:04bbe1bfe3a68bbfd4e52402ab7d4eb59d72d02647ae2042204326cf4bbad280"},
+    {file = "grpcio-1.76.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d388087771c837cdb6515539f43b9d4bf0b0f23593a24054ac16f7a960be16f4"},
+    {file = "grpcio-1.76.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:9f8f757bebaaea112c00dba718fc0d3260052ce714e25804a03f93f5d1c6cc11"},
+    {file = "grpcio-1.76.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:980a846182ce88c4f2f7e2c22c56aefd515daeb36149d1c897f83cf57999e0b6"},
+    {file = "grpcio-1.76.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f92f88e6c033db65a5ae3d97905c8fea9c725b63e28d5a75cb73b49bda5024d8"},
+    {file = "grpcio-1.76.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4baf3cbe2f0be3289eb68ac8ae771156971848bb8aaff60bad42005539431980"},
+    {file = "grpcio-1.76.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:615ba64c208aaceb5ec83bfdce7728b80bfeb8be97562944836a7a0a9647d882"},
+    {file = "grpcio-1.76.0-cp312-cp312-win32.whl", hash = "sha256:45d59a649a82df5718fd9527ce775fd66d1af35e6d31abdcdc906a49c6822958"},
+    {file = "grpcio-1.76.0-cp312-cp312-win_amd64.whl", hash = "sha256:c088e7a90b6017307f423efbb9d1ba97a22aa2170876223f9709e9d1de0b5347"},
+    {file = "grpcio-1.76.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:26ef06c73eb53267c2b319f43e6634c7556ea37672029241a056629af27c10e2"},
+    {file = "grpcio-1.76.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:45e0111e73f43f735d70786557dc38141185072d7ff8dc1829d6a77ac1471468"},
+    {file = "grpcio-1.76.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83d57312a58dcfe2a3a0f9d1389b299438909a02db60e2f2ea2ae2d8034909d3"},
+    {file = "grpcio-1.76.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3e2a27c89eb9ac3d81ec8835e12414d73536c6e620355d65102503064a4ed6eb"},
+    {file = "grpcio-1.76.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61f69297cba3950a524f61c7c8ee12e55c486cb5f7db47ff9dcee33da6f0d3ae"},
+    {file = "grpcio-1.76.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6a15c17af8839b6801d554263c546c69c4d7718ad4321e3166175b37eaacca77"},
+    {file = "grpcio-1.76.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:25a18e9810fbc7e7f03ec2516addc116a957f8cbb8cbc95ccc80faa072743d03"},
+    {file = "grpcio-1.76.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:931091142fd8cc14edccc0845a79248bc155425eee9a98b2db2ea4f00a235a42"},
+    {file = "grpcio-1.76.0-cp313-cp313-win32.whl", hash = "sha256:5e8571632780e08526f118f74170ad8d50fb0a48c23a746bef2a6ebade3abd6f"},
+    {file = "grpcio-1.76.0-cp313-cp313-win_amd64.whl", hash = "sha256:f9f7bd5faab55f47231ad8dba7787866b69f5e93bc306e3915606779bbfb4ba8"},
+    {file = "grpcio-1.76.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:ff8a59ea85a1f2191a0ffcc61298c571bc566332f82e5f5be1b83c9d8e668a62"},
+    {file = "grpcio-1.76.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:06c3d6b076e7b593905d04fdba6a0525711b3466f43b3400266f04ff735de0cd"},
+    {file = "grpcio-1.76.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd5ef5932f6475c436c4a55e4336ebbe47bd3272be04964a03d316bbf4afbcbc"},
+    {file = "grpcio-1.76.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b331680e46239e090f5b3cead313cc772f6caa7d0fc8de349337563125361a4a"},
+    {file = "grpcio-1.76.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2229ae655ec4e8999599469559e97630185fdd53ae1e8997d147b7c9b2b72cba"},
+    {file = "grpcio-1.76.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:490fa6d203992c47c7b9e4a9d39003a0c2bcc1c9aa3c058730884bbbb0ee9f09"},
+    {file = "grpcio-1.76.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:479496325ce554792dba6548fae3df31a72cef7bad71ca2e12b0e58f9b336bfc"},
+    {file = "grpcio-1.76.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1c9b93f79f48b03ada57ea24725d83a30284a012ec27eab2cf7e50a550cbbbcc"},
+    {file = "grpcio-1.76.0-cp314-cp314-win32.whl", hash = "sha256:747fa73efa9b8b1488a95d0ba1039c8e2dca0f741612d80415b1e1c560febf4e"},
+    {file = "grpcio-1.76.0-cp314-cp314-win_amd64.whl", hash = "sha256:922fa70ba549fce362d2e2871ab542082d66e2aaf0c19480ea453905b01f384e"},
+    {file = "grpcio-1.76.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:8ebe63ee5f8fa4296b1b8cfc743f870d10e902ca18afc65c68cf46fd39bb0783"},
+    {file = "grpcio-1.76.0-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:3bf0f392c0b806905ed174dcd8bdd5e418a40d5567a05615a030a5aeddea692d"},
+    {file = "grpcio-1.76.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b7604868b38c1bfd5cf72d768aedd7db41d78cb6a4a18585e33fb0f9f2363fd"},
+    {file = "grpcio-1.76.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:e6d1db20594d9daba22f90da738b1a0441a7427552cc6e2e3d1297aeddc00378"},
+    {file = "grpcio-1.76.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d099566accf23d21037f18a2a63d323075bebace807742e4b0ac210971d4dd70"},
+    {file = "grpcio-1.76.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ebea5cc3aa8ea72e04df9913492f9a96d9348db876f9dda3ad729cfedf7ac416"},
+    {file = "grpcio-1.76.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:0c37db8606c258e2ee0c56b78c62fc9dee0e901b5dbdcf816c2dd4ad652b8b0c"},
+    {file = "grpcio-1.76.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:ebebf83299b0cb1721a8859ea98f3a77811e35dce7609c5c963b9ad90728f886"},
+    {file = "grpcio-1.76.0-cp39-cp39-win32.whl", hash = "sha256:0aaa82d0813fd4c8e589fac9b65d7dd88702555f702fb10417f96e2a2a6d4c0f"},
+    {file = "grpcio-1.76.0-cp39-cp39-win_amd64.whl", hash = "sha256:acab0277c40eff7143c2323190ea57b9ee5fd353d8190ee9652369fae735668a"},
+    {file = "grpcio-1.76.0.tar.gz", hash = "sha256:7be78388d6da1a25c0d5ec506523db58b18be22d9c37d8d3a32c08be4987bd73"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.12,<5.0"
+
+[package.extras]
+protobuf = ["grpcio-tools (>=1.76.0)"]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -1712,6 +1789,22 @@ files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
 ]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+description = "Pure-Python HTTP/2 protocol implementation"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd"},
+    {file = "h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1"},
+]
+
+[package.dependencies]
+hpack = ">=4.1,<5"
+hyperframe = ">=6.1,<7"
 
 [[package]]
 name = "hf-xet"
@@ -1761,6 +1854,18 @@ pyviz-comms = ">=2.1"
 recommended = ["matplotlib (>=3)", "plotly (>=4.0)"]
 
 [[package]]
+name = "hpack"
+version = "4.1.0"
+description = "Pure-Python HPACK header encoding"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"},
+    {file = "hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca"},
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 description = "A minimal low-level HTTP client."
@@ -1797,6 +1902,7 @@ files = [
 [package.dependencies]
 anyio = "*"
 certifi = "*"
+h2 = {version = ">=3,<5", optional = true, markers = "extra == \"http2\""}
 httpcore = "==1.*"
 idna = "*"
 
@@ -1845,6 +1951,18 @@ tensorflow-testing = ["keras (<3.0)", "tensorflow"]
 testing = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "authlib (>=1.3.2)", "fastapi", "gradio (>=4.0.0)", "httpx", "itsdangerous", "jedi", "numpy", "pytest (>=8.1.1,<8.2.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures", "pytest-vcr", "pytest-xdist", "soundfile", "urllib3 (<2.0)"]
 torch = ["safetensors[torch]", "torch"]
 typing = ["types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)"]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+description = "Pure-Python HTTP/2 framing"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"},
+    {file = "hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08"},
+]
 
 [[package]]
 name = "idna"
@@ -2842,6 +2960,23 @@ files = [
 [package.dependencies]
 azure-search-documents = ">=11.5.1,<12"
 llama-index-core = ">=0.12.0,<0.13"
+
+[[package]]
+name = "llama-index-vector-stores-qdrant"
+version = "0.6.1"
+description = "llama-index vector_stores qdrant integration"
+optional = false
+python-versions = "<3.14,>=3.9"
+groups = ["main"]
+files = [
+    {file = "llama_index_vector_stores_qdrant-0.6.1-py3-none-any.whl", hash = "sha256:f41fa4cfcefaa176c4e4d54b846e83a718e05a3985e4dc468bd5aec4ae7af7d2"},
+    {file = "llama_index_vector_stores_qdrant-0.6.1.tar.gz", hash = "sha256:d78850fcc0abc1fd6db9c569acf6e8da62d1b8159a1c8d12e75e6c6cd0774352"},
+]
+
+[package.dependencies]
+grpcio = ">=1.60.0,<2"
+llama-index-core = ">=0.12.7,<0.13"
+qdrant-client = ">=1.7.1"
 
 [[package]]
 name = "llama-index-workflows"
@@ -4133,6 +4268,26 @@ dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
+name = "portalocker"
+version = "3.2.0"
+description = "Wraps the portalocker recipe for easy usage"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968"},
+    {file = "portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac"},
+]
+
+[package.dependencies]
+pywin32 = {version = ">=226", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+docs = ["portalocker[tests]"]
+redis = ["redis"]
+tests = ["coverage-conditional-plugin (>=0.9.0)", "portalocker[redis]", "pytest (>=5.4.1)", "pytest-cov (>=2.8.1)", "pytest-mypy (>=0.8.0)", "pytest-rerunfailures (>=15.0)", "pytest-timeout (>=2.1.0)", "sphinx (>=6.0.0)", "types-pywin32 (>=310.0.0.20250429)", "types-redis"]
+
+[[package]]
 name = "prometheus-client"
 version = "0.22.1"
 description = "Python client for the Prometheus monitoring system."
@@ -4268,6 +4423,26 @@ files = [
     {file = "propcache-0.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:7a2368eed65fc69a7a7a40b27f22e85e7627b74216f0846b04ba5c116e191ec9"},
     {file = "propcache-0.3.2-py3-none-any.whl", hash = "sha256:98f1ec44fb675f5052cccc8e609c46ed23a35a1cfd18545ad4e29002d858a43f"},
     {file = "propcache-0.3.2.tar.gz", hash = "sha256:20d7d62e4e7ef05f221e0db2856b979540686342e7dd9973b815599c7057e168"},
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.0"
+description = ""
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "protobuf-6.33.0-cp310-abi3-win32.whl", hash = "sha256:d6101ded078042a8f17959eccd9236fb7a9ca20d3b0098bbcb91533a5680d035"},
+    {file = "protobuf-6.33.0-cp310-abi3-win_amd64.whl", hash = "sha256:9a031d10f703f03768f2743a1c403af050b6ae1f3480e9c140f39c45f81b13ee"},
+    {file = "protobuf-6.33.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:905b07a65f1a4b72412314082c7dbfae91a9e8b68a0cc1577515f8df58ecf455"},
+    {file = "protobuf-6.33.0-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e0697ece353e6239b90ee43a9231318302ad8353c70e6e45499fa52396debf90"},
+    {file = "protobuf-6.33.0-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:e0a1715e4f27355afd9570f3ea369735afc853a6c3951a6afe1f80d8569ad298"},
+    {file = "protobuf-6.33.0-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:35be49fd3f4fefa4e6e2aacc35e8b837d6703c37a2168a55ac21e9b1bc7559ef"},
+    {file = "protobuf-6.33.0-cp39-cp39-win32.whl", hash = "sha256:cd33a8e38ea3e39df66e1bbc462b076d6e5ba3a4ebbde58219d777223a7873d3"},
+    {file = "protobuf-6.33.0-cp39-cp39-win_amd64.whl", hash = "sha256:c963e86c3655af3a917962c9619e1a6b9670540351d7af9439d06064e3317cc9"},
+    {file = "protobuf-6.33.0-py3-none-any.whl", hash = "sha256:25c9e1963c6734448ea2d308cfa610e692b801304ba0908d7bfa564ac5132995"},
+    {file = "protobuf-6.33.0.tar.gz", hash = "sha256:140303d5c8d2037730c548f8c7b93b20bb1dc301be280c378b82b8894589c954"},
 ]
 
 [[package]]
@@ -4742,8 +4917,7 @@ version = "311"
 description = "Python for Window Extensions"
 optional = false
 python-versions = "*"
-groups = ["graph-viz"]
-markers = "sys_platform == \"win32\" and platform_python_implementation != \"PyPy\""
+groups = ["main", "graph-viz"]
 files = [
     {file = "pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3"},
     {file = "pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b"},
@@ -4766,6 +4940,7 @@ files = [
     {file = "pywin32-311-cp39-cp39-win_amd64.whl", hash = "sha256:e0c4cfb0621281fe40387df582097fd796e80430597cb9944f0ae70447bacd91"},
     {file = "pywin32-311-cp39-cp39-win_arm64.whl", hash = "sha256:62ea666235135fee79bb154e695f3ff67370afefd71bd7fea7512fc70ef31e3d"},
 ]
+markers = {main = "platform_system == \"Windows\"", graph-viz = "sys_platform == \"win32\" and platform_python_implementation != \"PyPy\""}
 
 [[package]]
 name = "pywinpty"
@@ -4939,6 +5114,31 @@ files = [
 
 [package.dependencies]
 cffi = {version = "*", markers = "implementation_name == \"pypy\""}
+
+[[package]]
+name = "qdrant-client"
+version = "1.15.1"
+description = "Client library for the Qdrant vector search engine"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "qdrant_client-1.15.1-py3-none-any.whl", hash = "sha256:2b975099b378382f6ca1cfb43f0d59e541be6e16a5892f282a4b8de7eff5cb63"},
+    {file = "qdrant_client-1.15.1.tar.gz", hash = "sha256:631f1f3caebfad0fd0c1fba98f41be81d9962b7bf3ca653bed3b727c0e0cbe0e"},
+]
+
+[package.dependencies]
+grpcio = ">=1.41.0"
+httpx = {version = ">=0.20.0", extras = ["http2"]}
+numpy = {version = ">=1.21", markers = "python_version >= \"3.10\" and python_version < \"3.12\""}
+portalocker = ">=2.7.0,<4.0"
+protobuf = ">=3.20.0"
+pydantic = ">=1.10.8,<2.0.dev0 || >2.2.0"
+urllib3 = ">=1.26.14,<3"
+
+[package.extras]
+fastembed = ["fastembed (>=0.7,<0.8)"]
+fastembed-gpu = ["fastembed-gpu (>=0.7,<0.8)"]
 
 [[package]]
 name = "referencing"
@@ -5934,17 +6134,18 @@ files = []
 develop = true
 
 [package.dependencies]
-azure-identity = "^1.15.0"
-azure-search-documents = "11.5.1"
-llama-index-core = "0.12.48"
-llama-index-embeddings-azure-openai = "0.3.9"
-llama-index-embeddings-openai = "0.3.1"
-llama-index-instrumentation = "0.2.0"
-llama-index-llms-azure-openai = "0.3.4"
-llama-index-llms-openai = "0.4.7"
-llama-index-vector-stores-azureaisearch = "0.3.8"
-llama-index-workflows = "1.1.0"
-nest-asyncio = "^1.6.0"
+azure-identity = "*"
+azure-search-documents = "*"
+llama-index-core = "*"
+llama-index-embeddings-azure-openai = "*"
+llama-index-embeddings-openai = "*"
+llama-index-instrumentation = "*"
+llama-index-llms-azure-openai = "*"
+llama-index-llms-openai = "*"
+llama-index-vector-stores-azureaisearch = "*"
+llama-index-vector-stores-qdrant = "*"
+llama-index-workflows = "*"
+nest-asyncio = "*"
 openai = "*"
 python-dotenv = "*"
 tenacity = "*"

--- a/shiksha-ingestion/pyproject.toml
+++ b/shiksha-ingestion/pyproject.toml
@@ -51,11 +51,11 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies.ingestion-pipeline]
-path = "/home/kchourasia/ShikshaOSSNew/Shiksha-Copilot/components/ingestion-pipeline"
+path = "../components/ingestion-pipeline"
 develop = true
 
 [tool.poetry.dependencies.vellm-rag-wrapper]
-path = "/home/kchourasia/ShikshaOSSNew/Shiksha-Copilot/components/rag-wrapper"
+path = "../components/rag-wrapper"
 develop = true
 
 [tool.poetry.extras]


### PR DESCRIPTION
## Introduction
Shiksha-Ingestion is not readily usable at present due to hardcoded paths. This PR tweaks the setup by using CLI args in these places. Heavy memory requirement makes it difficult to run the ingestion pipeline locally, which has also been addressed here.

## Changes
* Replaced all direct `convert_from_path` calls with the new memory-efficient `convert_pdf_to_images` context manager across all extractors
* Fixed `create-index` step not registered in `pipeline_runner.py`, resulting in crash
* Added CLI argument `--textbook` to avoid hardcoded PDF paths
* Adjusted path handling in `pyproject.toml` to use relative component paths instead of absolute ones