### PR TITLE
backend: read cors origins from env

### DIFF
--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -66,8 +66,6 @@ jobs:
         with:
           context: shiksha-website/shiksha-backend
           file: shiksha-website/shiksha-backend/Dockerfile
-          build-args: |
-            ALLOW_ORIGIN=${{ vars.BACKEND_ALLOW_ORIGIN }}
           push: false
           tags: shiksha-backend-local
           load: true
@@ -154,8 +152,6 @@ jobs:
         with:
           context: shiksha-website/shiksha-backend
           file: shiksha-website/shiksha-backend/Dockerfile
-          build-args: |
-            ALLOW_ORIGIN=${{ vars.BACKEND_ALLOW_ORIGIN }}
           push: true
           tags: ${{ needs.build-test.outputs.image_tag }}
           cache-from: type=gha

--- a/shiksha-website/shiksha-backend/Dockerfile
+++ b/shiksha-website/shiksha-backend/Dockerfile
@@ -7,9 +7,6 @@ RUN npm install --omit=dev
 
 COPY . .
 
-ARG ALLOW_ORIGIN
-RUN if [ -n "$ALLOW_ORIGIN" ]; then sed -i "s|allow_your_website_here|$ALLOW_ORIGIN|g" app.js; fi
-
 EXPOSE 8080
 
 CMD ["node", "app.js"]

--- a/shiksha-website/shiksha-backend/app.js
+++ b/shiksha-website/shiksha-backend/app.js
@@ -39,24 +39,9 @@ const app = express();
 app.disable("x-powered-by");
 
 app.use(express.json());
-const allowedOrigins = ["allow_your_website_here"];
 
-app.use(
-	cors({
-		origin: function (origin, callback) {
-			if (!origin) return callback(null, true);
-			if (
-				allowedOrigins.includes(origin) ||
-				/^http:\/\/localhost:\d+$/.test(origin)
-			) {
-				return callback(null, true);
-			} else {
-				return callback(new Error("Not allowed by CORS"));
-			}
-		},
-		optionsSuccessStatus: 200,
-	})
-);
+const allowedOrigins = process.env.ALLOWED_ORIGINS ? process.env.ALLOWED_ORIGINS.split(",") : [/^http:\/\/localhost:\d+$/];
+app.use(cors({origin: allowedOrigins, optionsSuccessStatus: 200}));
 
 const folderPath = path.join(__dirname, 'public', 'images');
 


### PR DESCRIPTION
## Introduction
Tweaking CORS rules requires running a `sed/find/replace` which is not a feasible approach because Docker images must be rebuilt for any CORS rule change. This especially becomes impractical when GHCR images in Azure Web App cannot be conveniently reused in Azure Web App because they contain the hardcoded string "https://a4i-tech.github.io" (injected by Dockerfile's RUN command).

## Behaviour change
Changes in this PR are more or less backward-compatible for dev deployments. Fallback `[/^http:\/\/localhost:\d+$/]` is in effect when `ALLOWED_ORIGINS` env is not defined. Existing prod setups relying on sed/f/r must now use `ALLOWED_ORIGINS` env:
- To allow multiple origins, use comma as delimiter (e.g., `ALLOW_ORIGINS=https://a4i-tech.github.io,http://example.com`
- To allow all origins, set `ALLOW_ORIGINS=*`

Particularly, this env is directly passed to `cors({orign: ...})` - docs on cors() here: https://expressjs.com/en/resources/middleware/cors.html

## Follow-up task
- [x] Remove `BACKEND_ALLOW_ORIGIN` repository variable
- [x] Define `ALLOW_ORIGINS` env in staging setup (Render)
- [ ] Platforms like Azure actually offer users to define CORS rules - check if we can use Azure's CORS handler as the primary mechanism, or even as an exclusive mechanism (by effectively disabling application-side cors resolution using `ALLOWED_ORIGINS=*`). More info here: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-rest-api
   <img width="1909" height="711" alt="image" src="https://github.com/user-attachments/assets/9936edeb-7ae3-46f2-87d4-adb0dcd50bb8" />
