### PR TITLE
fixed info icon not showing

### DIFF
--- a/shiksha-website/shiksha-frontend/src/app/shared/components/form-dropdown/form-dropdown.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/shared/components/form-dropdown/form-dropdown.component.ts
@@ -199,6 +199,13 @@ export class FormDropdownComponent implements OnInit, OnChanges {
     }
 
     if (this.config.bindValue && this.dropDownValues?.length > 0) {
+      // If value is an object, try to match by its bindValue property
+      if (typeof value === 'object' && value[this.config.bindValue] !== undefined) {
+        return this.dropDownValues.find(
+          (item) => item && item[this.config.bindValue!] === value[this.config.bindValue!]
+        );
+      }
+
       return this.dropDownValues.find(
         (item) => item && item[this.config.bindValue!] === value
       );


### PR DESCRIPTION
1. **Dropdown Object Matching**: The Chip dropdown UI was comparing object-based selection values instead of strings causing the `info` text lookup to fail. I added logic so the dropdown could correctly identify the selected object.
2. **Missing Info Text on Rerender**: Selecting a new Board triggered an override function that recreated the "AI/Pregenerated" label options, but it was missing the `info` text definition entirely. I added the text back into the array creation method.
