### PR TITLE
cicd: fix cache busting failure causing stale frontend after deploy

### DIFF
--- a/.github/workflows/cicd-frontend.yaml
+++ b/.github/workflows/cicd-frontend.yaml
@@ -8,6 +8,10 @@ on:
         description: "Name of the deployment"
         required: true
         type: string
+      environment:
+        description: "Environment to build the frontend for"
+        required: true
+        type: string
       api_url:
         description: "Backend API URL this frontend resource must call"
         required: true
@@ -73,11 +77,12 @@ jobs:
         working-directory: shiksha-website/shiksha-frontend
         run: |
           if [ "${{ inputs.deploy_target }}" != "" ]; then
-            sed -i "s|your_backend_url|${BACKEND_URL}|g" src/environments/environment.prod.ts
+            find src/environments -name "environment*.ts" -print \
+              -exec sed -i "s|your_backend_url|${BACKEND_URL}|g" {} \;
           fi
 
           npm ci
-          npm run build -- --configuration production \
+          npm run build -- --configuration ${{ inputs.environment }} \
             ${{ inputs.deploy_target == 'github-pages' && '--base-href /Shiksha-Copilot/' || '' }}
 
       - name: Setup Pages

--- a/.github/workflows/cicd-frontend.yaml
+++ b/.github/workflows/cicd-frontend.yaml
@@ -73,12 +73,11 @@ jobs:
         working-directory: shiksha-website/shiksha-frontend
         run: |
           if [ "${{ inputs.deploy_target }}" != "" ]; then
-            find src/environments -name "environment*.ts" -print \
-              -exec sed -i "s|your_backend_url|${BACKEND_URL}|g" {} \;
+            sed -i "s|your_backend_url|${BACKEND_URL}|g" src/environments/environment.prod.ts
           fi
 
           npm ci
-          npm run build -- --configuration development \
+          npm run build -- --configuration production \
             ${{ inputs.deploy_target == 'github-pages' && '--base-href /Shiksha-Copilot/' || '' }}
 
       - name: Setup Pages

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,6 +59,7 @@ jobs:
     with:
       deploy_name: shiksha-frontend-staging
       deploy_target: ${{ needs.cd-backend.result == 'success' && 'github-pages' || '' }}
+      environment: uat
       api_url: ${{ needs.cd-backend.result == 'success' && format('{0}/api', needs.cd-backend.outputs['service-url']) || '' }}
 
   cd-api-prod:
@@ -91,6 +92,7 @@ jobs:
     with:
       deploy_name: shiksha-frontend-prod
       deploy_target: ${{ github.event_name == 'push' && github.ref_name == 'a4i/main' && 'azure-blob' || '' }}
+      environment: production
       api_url: ${{ needs.cd-backend-prod.result == 'success' && format('{0}/api', needs.cd-backend-prod.outputs['service-url']) || '' }}
 
   health-check:

--- a/shiksha-website/shiksha-frontend/src/environments/environment.uat.ts
+++ b/shiksha-website/shiksha-frontend/src/environments/environment.uat.ts
@@ -1,0 +1,6 @@
+export const environment = {
+    production:false,
+    apiUrl:'your_backend_url',
+    CRYPTO_SECRET:'your_crypto_secret',
+    EXP_MONTH: 3
+};


### PR DESCRIPTION
## Summary
CI pipeline was producing non-hashed Angular bundles which caused browsers to cache core files like main.js, vendor.js, and runtime.js. Users continued to load outdated frontend code even after new releases leading to mismatched UI.

## Approach
Deployments now generate hashed bundle filenames so each deployment produces unique asset URLs which forcess browsers to fetch latest version instead of serving stale cached files.

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/dc295f9a-3621-46ad-9d96-e7742d5a9b38) | ![After](https://github.com/user-attachments/assets/2c32efc8-052e-49d8-b6ba-769580cba685) |