### PR TITLE
auth: assume user can have both admin and teacher profiles

### DIFF
--- a/.github/workflows/cicd-frontend.yaml
+++ b/.github/workflows/cicd-frontend.yaml
@@ -8,6 +8,10 @@ on:
         description: "Name of the deployment"
         required: true
         type: string
+      environment:
+        description: "Environment to build the frontend for"
+        required: true
+        type: string
       api_url:
         description: "Backend API URL this frontend resource must call"
         required: true
@@ -78,7 +82,7 @@ jobs:
           fi
 
           npm ci
-          npm run build -- --configuration development \
+          npm run build -- --configuration ${{ inputs.environment }} \
             ${{ inputs.deploy_target == 'github-pages' && '--base-href /Shiksha-Copilot/' || '' }}
 
       - name: Setup Pages

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,6 +59,7 @@ jobs:
     with:
       deploy_name: shiksha-frontend-staging
       deploy_target: ${{ needs.cd-backend.result == 'success' && 'github-pages' || '' }}
+      environment: uat
       api_url: ${{ needs.cd-backend.result == 'success' && format('{0}/api', needs.cd-backend.outputs['service-url']) || '' }}
 
   cd-api-prod:
@@ -91,6 +92,7 @@ jobs:
     with:
       deploy_name: shiksha-frontend-prod
       deploy_target: ${{ github.event_name == 'push' && github.ref_name == 'a4i/main' && 'azure-blob' || '' }}
+      environment: production
       api_url: ${{ needs.cd-backend-prod.result == 'success' && format('{0}/api', needs.cd-backend-prod.outputs['service-url']) || '' }}
 
   health-check:

--- a/shiksha-website/shiksha-backend/__tests__/unit/controllers/auth.controller.test.js
+++ b/shiksha-website/shiksha-backend/__tests__/unit/controllers/auth.controller.test.js
@@ -22,44 +22,11 @@ describe('AuthController', () => {
             json: jest.fn().mockReturnThis()
         };
         mockAuthManager = {
-            getOtp: jest.fn(),
             validateOtp: jest.fn(),
             getUserFromToken: jest.fn()
         };
         authController.authManager = mockAuthManager;
         jest.clearAllMocks();
-    });
-
-    describe('getOtp', () => {
-        it('should return 200 when OTP is sent successfully', async () => {
-            const mockResult = { success: true, message: 'OTP sent', data: null };
-            mockAuthManager.getOtp.mockResolvedValue(mockResult);
-
-            await authController.getOtp(mockReq, mockRes);
-
-            expect(mockAuthManager.getOtp).toHaveBeenCalledWith(mockReq);
-            expect(mockRes.status).toHaveBeenCalledWith(200);
-            expect(mockRes.json).toHaveBeenCalledWith(mockResult);
-        });
-
-        it('should handle error when OTP sending fails', async () => {
-            const mockResult = { success: false, message: 'Failed to send OTP', data: null };
-            mockAuthManager.getOtp.mockResolvedValue(mockResult);
-
-            await authController.getOtp(mockReq, mockRes);
-
-            expect(handleError).toHaveBeenCalledWith(mockResult, mockRes);
-        });
-
-        it('should return 400 when exception occurs', async () => {
-            const error = new Error('Database error');
-            mockAuthManager.getOtp.mockRejectedValue(error);
-
-            await authController.getOtp(mockReq, mockRes);
-
-            expect(mockRes.status).toHaveBeenCalledWith(400);
-            expect(mockRes.json).toHaveBeenCalledWith(error);
-        });
     });
 
     describe('validateOtp', () => {

--- a/shiksha-website/shiksha-backend/__tests__/unit/helper/auth.helper.test.js
+++ b/shiksha-website/shiksha-backend/__tests__/unit/helper/auth.helper.test.js
@@ -8,9 +8,9 @@ describe('AuthHelper', () => {
         jest.clearAllMocks();
     });
 
-    describe('getOtp', () => {
+    describe('generateOtp', () => {
         it('should generate a 4-digit OTP', () => {
-            const otp = authHelper.getOtp();
+            const otp = authHelper.generateOtp();
 
             expect(otp).toBeDefined();
             expect(otp).toHaveLength(4);
@@ -19,8 +19,8 @@ describe('AuthHelper', () => {
         });
 
         it('should generate different OTPs on multiple calls', () => {
-            const otp1 = authHelper.getOtp();
-            const otp2 = authHelper.getOtp();
+            const otp1 = authHelper.generateOtp();
+            const otp2 = authHelper.generateOtp();
 
             expect(typeof otp1).toBe('string');
             expect(typeof otp2).toBe('string');

--- a/shiksha-website/shiksha-backend/__tests__/unit/routes/routes.test.js
+++ b/shiksha-website/shiksha-backend/__tests__/unit/routes/routes.test.js
@@ -145,7 +145,7 @@ const loadRoute = (file) => {
 const routeCases = [
   { file: "admin.user.routes.js", method: "post", path: "/admin/create" },
   { file: "audit.log.route.js", method: "get", path: "/audit/log" },
-  { file: "auth.routes.js", method: "post", path: "/auth/get-otp" },
+  { file: "auth.routes.js", method: "post", path: "/auth/forgot-password" },
   {
     file: "baselineSurvey.routes.js",
     method: "get",

--- a/shiksha-website/shiksha-backend/__tests__/unit/validations/auth.validation.test.js
+++ b/shiksha-website/shiksha-backend/__tests__/unit/validations/auth.validation.test.js
@@ -1,4 +1,4 @@
-const { validateGetOtp, validateOtp } = require("../../../validations/auth.validation");
+const { validateOtp } = require("../../../validations/auth.validation");
 
 describe("Auth Validations", () => {
   let mockReq;
@@ -29,185 +29,11 @@ describe("Auth Validations", () => {
     consoleLogSpy.mockRestore();
   });
 
-  describe("validateGetOtp", () => {
-    it("should pass validation with valid phone number", () => {
-      mockReq.body = {
-        phone: "1234567890"
-      };
-
-      validateGetOtp(mockReq, mockRes, mockNext);
-
-      expect(mockNext).toHaveBeenCalled();
-      expect(mockRes.status).not.toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith("[validateGetOtp] Validation Passed");
-    });
-
-    it("should pass validation with phone and rememberMe", () => {
-      mockReq.body = {
-        phone: "1234567890",
-        rememberMe: true
-      };
-
-      validateGetOtp(mockReq, mockRes, mockNext);
-
-      expect(mockNext).toHaveBeenCalled();
-      expect(mockRes.status).not.toHaveBeenCalled();
-    });
-
-    it("should pass validation with phone and forgotPassword", () => {
-      mockReq.body = {
-        phone: "1234567890",
-        forgotPassword: true
-      };
-
-      validateGetOtp(mockReq, mockRes, mockNext);
-
-      expect(mockNext).toHaveBeenCalled();
-    });
-
-    it("should pass validation with all fields", () => {
-      mockReq.body = {
-        phone: "1234567890",
-        rememberMe: true,
-        forgotPassword: false
-      };
-
-      validateGetOtp(mockReq, mockRes, mockNext);
-
-      expect(mockNext).toHaveBeenCalled();
-    });
-
-    it("should fail validation when phone is missing", () => {
-      mockReq.body = {
-        rememberMe: true
-      };
-
-      validateGetOtp(mockReq, mockRes, mockNext);
-
-      expect(mockNext).not.toHaveBeenCalled();
-      expect(mockRes.status).toHaveBeenCalledWith(400);
-      expect(mockRes.json).toHaveBeenCalledWith({
-        success: false,
-        data: false,
-        error: expect.arrayContaining([
-          expect.stringContaining('"phone" is required')
-        ])
-      });
-    });
-
-    it("should fail validation when phone is empty string", () => {
-      mockReq.body = {
-        phone: ""
-      };
-
-      validateGetOtp(mockReq, mockRes, mockNext);
-
-      expect(mockNext).not.toHaveBeenCalled();
-      expect(mockRes.status).toHaveBeenCalledWith(400);
-      expect(mockRes.json).toHaveBeenCalledWith({
-        success: false,
-        data: false,
-        error: expect.arrayContaining([
-          expect.stringContaining('"phone" is not allowed to be empty')
-        ])
-      });
-    });
-
-    it("should fail validation when phone is not a string", () => {
-      mockReq.body = {
-        phone: 1234567890
-      };
-
-      validateGetOtp(mockReq, mockRes, mockNext);
-
-      expect(mockNext).not.toHaveBeenCalled();
-      expect(mockRes.status).toHaveBeenCalledWith(400);
-      expect(mockRes.json).toHaveBeenCalledWith({
-        success: false,
-        data: false,
-        error: expect.arrayContaining([
-          expect.stringContaining('"phone" must be a string')
-        ])
-      });
-    });
-
-    it("should fail validation when rememberMe is not a boolean", () => {
-      mockReq.body = {
-        phone: "1234567890",
-        rememberMe: "yes"
-      };
-
-      validateGetOtp(mockReq, mockRes, mockNext);
-
-      expect(mockNext).not.toHaveBeenCalled();
-      expect(mockRes.status).toHaveBeenCalledWith(400);
-      expect(mockRes.json).toHaveBeenCalledWith({
-        success: false,
-        data: false,
-        error: expect.arrayContaining([
-          expect.stringContaining('"rememberMe" must be a boolean')
-        ])
-      });
-    });
-
-    it("should fail validation when forgotPassword is not a boolean", () => {
-      mockReq.body = {
-        phone: "1234567890",
-        forgotPassword: "no"
-      };
-
-      validateGetOtp(mockReq, mockRes, mockNext);
-
-      expect(mockNext).not.toHaveBeenCalled();
-      expect(mockRes.status).toHaveBeenCalledWith(400);
-    });
-
-    it("should fail validation with multiple errors", () => {
-      mockReq.body = {
-        rememberMe: "not-boolean"
-      };
-
-      validateGetOtp(mockReq, mockRes, mockNext);
-
-      expect(mockNext).not.toHaveBeenCalled();
-      expect(mockRes.status).toHaveBeenCalledWith(400);
-      expect(mockRes.json).toHaveBeenCalledWith({
-        success: false,
-        data: false,
-        error: expect.arrayContaining([
-          expect.stringContaining('"phone" is required'),
-          expect.stringContaining('"rememberMe" must be a boolean')
-        ])
-      });
-    });
-
-    it("should log incoming request details", () => {
-      mockReq.query = { test: "value" };
-      mockReq.body = { phone: "1234567890" };
-
-      validateGetOtp(mockReq, mockRes, mockNext);
-
-      expect(consoleLogSpy).toHaveBeenCalledWith("\n[validateGetOtp] Incoming Request:");
-      expect(consoleLogSpy).toHaveBeenCalledWith("Query Params (URL):", mockReq.query);
-      expect(consoleLogSpy).toHaveBeenCalledWith("Body (Payload):", mockReq.body);
-    });
-
-    it("should log validation failure", () => {
-      mockReq.body = {};
-
-      validateGetOtp(mockReq, mockRes, mockNext);
-
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        "[validateGetOtp] Validation Failed:",
-        expect.any(Array)
-      );
-    });
-  });
-
   describe("validateOtp", () => {
-    it("should pass validation with valid phone and otp", () => {
+    it("should pass validation with valid phone, user type, and otp", () => {
       mockReq.body = {
         phone: "1234567890",
+        userType: "teacher",
         otp: "123456"
       };
 
@@ -217,30 +43,32 @@ describe("Auth Validations", () => {
       expect(mockRes.status).not.toHaveBeenCalled();
     });
 
-    it("should pass validation with phone only", () => {
+    it("should fail validation with phone only", () => {
       mockReq.body = {
         phone: "1234567890"
       };
 
       validateOtp(mockReq, mockRes, mockNext);
 
-      expect(mockNext).toHaveBeenCalled();
+      expect(mockNext).not.toHaveBeenCalled();
     });
 
-    it("should pass validation with phone and rememberMe", () => {
+    it("should fail validation with phone, user type, and rememberMe", () => {
       mockReq.body = {
         phone: "1234567890",
+        userType: "teacher",
         rememberMe: true
       };
 
       validateOtp(mockReq, mockRes, mockNext);
 
-      expect(mockNext).toHaveBeenCalled();
+      expect(mockNext).not.toHaveBeenCalled();
     });
 
     it("should pass validation with all fields", () => {
       mockReq.body = {
         phone: "1234567890",
+        userType: "teacher",
         otp: "654321",
         rememberMe: false
       };
@@ -270,7 +98,9 @@ describe("Auth Validations", () => {
 
     it("should fail validation when phone is empty", () => {
       mockReq.body = {
-        phone: ""
+        phone: "",
+        userType: "teacher",
+        otp: "0000"
       };
 
       validateOtp(mockReq, mockRes, mockNext);
@@ -282,6 +112,7 @@ describe("Auth Validations", () => {
     it("should fail validation when phone is not a string", () => {
       mockReq.body = {
         phone: 1234567890,
+        userType: "teacher",
         otp: "123456"
       };
 
@@ -301,6 +132,7 @@ describe("Auth Validations", () => {
     it("should fail validation when otp is not a string", () => {
       mockReq.body = {
         phone: "1234567890",
+        userType: "teacher",
         otp: 123456
       };
 
@@ -320,6 +152,8 @@ describe("Auth Validations", () => {
     it("should fail validation when rememberMe is not a boolean", () => {
       mockReq.body = {
         phone: "1234567890",
+        userType: "teacher",
+        otp: "9999",
         rememberMe: "yes"
       };
 
@@ -348,15 +182,6 @@ describe("Auth Validations", () => {
           expect.stringContaining('"rememberMe" must be a boolean')
         ])
       });
-    });
-
-    it("should log incoming request details", () => {
-      mockReq.body = { phone: "1234567890", otp: "123456" };
-
-      validateOtp(mockReq, mockRes, mockNext);
-
-      expect(consoleLogSpy).toHaveBeenCalledWith("\n[validateOtp] Incoming Request:");
-      expect(consoleLogSpy).toHaveBeenCalledWith("Body (Payload):", mockReq.body);
     });
 
     it("should log validation failure", () => {

--- a/shiksha-website/shiksha-backend/controllers/auth.controller.js
+++ b/shiksha-website/shiksha-backend/controllers/auth.controller.js
@@ -5,24 +5,21 @@ class AuthController {
     constructor() {
         this.authManager = new AuthManager();
     }
+    async getUserTypes(req, res) {
+        const result = await this.authManager.getUserTypes(req.query.phone);
+        return res.status(200).json(result);
+    }
 
-    async getOtp(req, res) {
+    async forgotPassword(req, res) {
         try {
-            console.log("--> [Controller] Calling authManager.getOtp");
-            
-            // Call the Manager
-            let result = await this.authManager.getOtp(req);
-            
-            console.log("--> [Controller] Result received:", JSON.stringify(result));
-
+            let result = await this.authManager.forgotPassword(req);
             if (result.success) {
                 return res.status(200).json(result);
             }
-
             handleError(result, res);
             return;
         } catch (err) {
-            console.log("Error --> AuthController -> getOtp()", err);
+            console.log("Error --> AuthController -> forgotPassword()", err);
             return res.status(400).json(err);
         }
     }

--- a/shiksha-website/shiksha-backend/helper/auth.helper.js
+++ b/shiksha-website/shiksha-backend/helper/auth.helper.js
@@ -2,7 +2,7 @@ require("dotenv").config();
 const crypto = require('crypto');
 const variforrmSMSService = require('../services/variform.service');
 class AuthHelper {
-	getOtp() {
+	generateOtp() {
         const OTP = crypto.randomInt(1000, 10000).toString();
 		return OTP;
 	}

--- a/shiksha-website/shiksha-backend/managers/auth.manager.js
+++ b/shiksha-website/shiksha-backend/managers/auth.manager.js
@@ -27,8 +27,8 @@ class AuthManager {
 
     async updateUserByType(userId, userType, updates) {
         switch (userType) {
-            case "admin": await this.adminUserDao.update(userId, updates);
-            case "teacher": await this.userDao.update(userId, updates);
+            case "admin": return await this.adminUserDao.update(userId, updates);
+            case "teacher": return await this.userDao.update(userId, updates);
             default: throw new Error(`Unexpected user type: ${userType}`);
         }
     }

--- a/shiksha-website/shiksha-backend/managers/auth.manager.js
+++ b/shiksha-website/shiksha-backend/managers/auth.manager.js
@@ -64,7 +64,7 @@ class AuthManager {
             }
 
             await authHelper.sendOtp(process.env.VARIFORM_SMS_TEMPLATE, phone, otp);
-            return formatApiReponse(true, "OTP sent successfully", { user: user.phone, otpTriggered });
+            return formatApiReponse(true, "OTP sent successfully", { user: user.phone, otpTriggered: true });
         } catch (err) {
             return formatApiReponse(false, err?.message || "Internal Server Error", err);
         }

--- a/shiksha-website/shiksha-backend/managers/auth.manager.js
+++ b/shiksha-website/shiksha-backend/managers/auth.manager.js
@@ -17,82 +17,54 @@ class AuthManager {
         this.adminUserDao = new AdminUserDao();
     }
 
-    /**
-     * Auto-detect user type by searching both User and AdminUser tables
-     * @param {string} phone - Phone number to search
-     * @returns {object} { user: User|AdminUser|null, type: "0"|"1"|null }
-     */
-    async detectUserType(phone) {
-        // Try regular User table first (type=0)
-        const regularUser = await this.userDao.getByPhone(phone);
-        if (regularUser) {
-            return { user: regularUser, type: "0" };
-        }
-
-        // Try AdminUser table (type=1)
-        const adminUser = await this.adminUserDao.getByPhone(phone);
-        if (adminUser) {
-            return { user: adminUser, type: "1" };
-        }
-
-        return { user: null, type: null };
-    }
-
-    async updateUserByType(userId, type, updates) {
-        if (type === "0") {
-            await this.userDao.update(userId, updates);
-        } else if (type === "1") {
-            await this.adminUserDao.update(userId, updates);
-        } else {
-            throw new Error("Invalid type");
+    async #getUserByType(phone, userType) {
+        switch (userType) {
+            case "admin": return await this.adminUserDao.getByPhone(phone);
+            case "teacher": return await this.userDao.getByPhone(phone);
+            default: throw new Error(`Unexpected user type: ${userType}`);
         }
     }
 
-    async getOtp(req) {
+    async updateUserByType(userId, userType, updates) {
+        switch (userType) {
+            case "admin": await this.adminUserDao.update(userId, updates);
+            case "teacher": await this.userDao.update(userId, updates);
+            default: throw new Error(`Unexpected user type: ${userType}`);
+        }
+    }
+
+    async getUserTypes(phone) {
+        const [teacher, admin] = await Promise.all([this.#getUserByType(phone, "teacher"), this.#getUserByType(phone, "admin")]);
+        const types = [];
+        if(teacher) types.push("teacher");
+        if(admin) types.push("admin");
+        return formatApiReponse(true, null, types);
+    }
+
+    async forgotPassword(req) {
         try {
-            let { phone, rememberMe, forgotPassword } = req.body;
-
-            // Auto-detect user type by searching both tables
-            const detected = await this.detectUserType(phone);
-            if (!detected.user) {
+            let { phone, userType } = req.body;
+            const user = await this.#getUserByType(phone, userType);
+            if (!user) {
                 return formatApiReponse(false, "Account does not exist!", {});
             }
-
-            const user = detected.user;
-            const type = detected.type;
-            console.log(`[AUTH] User detected: phone=${phone}, type=${type} (${type === "0" ? "Teacher" : "Admin"})`);
 
             if (user.isDeleted) {
                 return formatApiReponse(false, "User is inactive", {});
             }
 
-            let otpTriggered = false;
-
-            if (forgotPassword || (!user.otp && !user.rememberMeToken)) {
-                if (user.otp && forgotPassword) {
-                    const decryptedOtpBytes = CryptoJS.AES.decrypt(user.otp, process.env.PIN_SECRET_KEY);
-                    const decryptedOtp = decryptedOtpBytes.toString(CryptoJS.enc.Utf8);
-
-                    const templateId = process.env.VARIFORM_SMS_TEMPLATE;
-                    await authHelper.sendOtp(templateId, phone, decryptedOtp);
-                    otpTriggered = true;
-                } else {
-                    const otp = authHelper.getOtp();
-                    const templateId = process.env.VARIFORM_SMS_TEMPLATE;
-                    await authHelper.sendOtp(templateId, phone, otp);
-                    const encryptedOtp = CryptoJS.AES.encrypt(otp, process.env.PIN_SECRET_KEY).toString();
-                    await this.updateUserByType(user._id, type, { otp: encryptedOtp, rememberMeToken: rememberMe === true });
-                    otpTriggered = true;
-                }
-            } else {
-                await this.updateUserByType(user._id, type, { rememberMeToken: rememberMe === true });
+            let otp;
+            if(!user.otp){
+                // this happens to new teachers - they do not get an otp assigned and must use 'forgot pin'
+                otp = authHelper.generateOtp();
+                const encryptedOtp = CryptoJS.AES.encrypt(otp, process.env.PIN_SECRET_KEY).toString();
+                await this.updateUserByType(user._id, type, { otp: encryptedOtp, rememberMeToken: rememberMe === true });
+            }else{
+                otp = CryptoJS.AES.decrypt(user.otp, process.env.PIN_SECRET_KEY).toString(CryptoJS.enc.Utf8);
             }
 
-            const userObj = user.toObject();
-            delete userObj.otp;
-            delete userObj.rememberMeToken;
-            return formatApiReponse(true, otpTriggered ? "OTP sent successfully" : "Verify your Pin!", { user: user.phone, otpTriggered });
-
+            await authHelper.sendOtp(process.env.VARIFORM_SMS_TEMPLATE, phone, otp);
+            return formatApiReponse(true, "OTP sent successfully", { user: user.phone, otpTriggered });
         } catch (err) {
             return formatApiReponse(false, err?.message || "Internal Server Error", err);
         }
@@ -100,17 +72,12 @@ class AuthManager {
 
     async validateOtp(req) {
         try {
-            let { phone, otp } = req.body;
+            let { phone, userType, otp, rememberMe } = req.body;
 
-            // Auto-detect user type by searching both tables
-            const detected = await this.detectUserType(phone);
-            if (!detected.user) {
+            const user = await this.#getUserByType(phone, userType);
+            if (!user) {
                 return formatApiReponse(false, "Account does not exist!", null);
             }
-
-            const user = detected.user;
-            const type = detected.type;
-            console.log(`[AUTH] OTP validation for: phone=${phone}, type=${type} (${type === "0" ? "Teacher" : "Admin"})`);
 
             if (user.isDeleted) {
                 return formatApiReponse(false, "User is inactive", {});
@@ -127,11 +94,11 @@ class AuthManager {
 
             if (isOtpValid) {
                 const token = user.generateAuthToken();
-                await this.updateUserByType(user._id, type, { isLoginAllowed: true });
+                await this.updateUserByType(user._id, userType, { isLoginAllowed: true, rememberMeToken: rememberMe === true });
                 const userObj = user.toObject();
 
                 // Refresh profile image SAS URL if expired
-                await refreshProfileImageIfExpired(userObj, (id, updates) => this.updateUserByType(id, type, updates));
+                await refreshProfileImageIfExpired(userObj, (id, updates) => this.updateUserByType(id, userType, updates));
 
                 // Logging logic
                 const agent = req.useragent || {};

--- a/shiksha-website/shiksha-backend/managers/auth.manager.js
+++ b/shiksha-website/shiksha-backend/managers/auth.manager.js
@@ -43,7 +43,7 @@ class AuthManager {
 
     async forgotPassword(req) {
         try {
-            let { phone, userType } = req.body;
+            let { phone, userType, rememberMe } = req.body;
             const user = await this.#getUserByType(phone, userType);
             if (!user) {
                 return formatApiReponse(false, "Account does not exist!", {});
@@ -58,7 +58,7 @@ class AuthManager {
                 // this happens to new teachers - they do not get an otp assigned and must use 'forgot pin'
                 otp = authHelper.generateOtp();
                 const encryptedOtp = CryptoJS.AES.encrypt(otp, process.env.PIN_SECRET_KEY).toString();
-                await this.updateUserByType(user._id, type, { otp: encryptedOtp, rememberMeToken: rememberMe === true });
+                await this.updateUserByType(user._id, userType, { otp: encryptedOtp, rememberMeToken: rememberMe === true });
             }else{
                 otp = CryptoJS.AES.decrypt(user.otp, process.env.PIN_SECRET_KEY).toString(CryptoJS.enc.Utf8);
             }

--- a/shiksha-website/shiksha-backend/routes/auth.routes.js
+++ b/shiksha-website/shiksha-backend/routes/auth.routes.js
@@ -3,18 +3,24 @@ const router = express.Router();
 const asyncMiddleware = require("../middlewares/asyncMiddleware.js");
 const AuthController = require("../controllers/auth.controller.js");
 const {
-	validateLogin,
 	validateOtp,
-	validateGetOtp
+	validateForgotPassword,
+	validateUserTypes
 } = require("../validations/auth.validation.js");
 const { isAuthenticated } = require("../middlewares/auth.js");
 
 const authController = new AuthController();
 
+router.get(
+	"/auth/user-types",
+	validateUserTypes,
+	asyncMiddleware(authController.getUserTypes.bind(authController))
+);
+
 router.post(
-	"/auth/get-otp",
-	validateGetOtp,
-	asyncMiddleware(authController.getOtp.bind(authController))
+	"/auth/forgot-password",
+	validateForgotPassword,
+	asyncMiddleware(authController.forgotPassword.bind(authController))
 );
 
 router.post(

--- a/shiksha-website/shiksha-backend/validations/auth.validation.js
+++ b/shiksha-website/shiksha-backend/validations/auth.validation.js
@@ -1,27 +1,30 @@
 const Joi = require("joi");
 
-const validateGetOtp = (req, res, next) => {
-    // --- LOGS START ---
-    console.log("\n[validateGetOtp] Incoming Request:");
-    console.log("Query Params (URL):", req.query);
-    console.log("Body (Payload):", req.body);
-    // --- LOGS END ---
+const validateUserTypes = (req, res, next) => {
+    const { error } = Joi.object({phone: Joi.string().required()}).validate(req.query, { abortEarly: false });
+    if (error) {
+        const errorMessages = error.details.map((i) => i.message);
+        console.log("[validateUserTypes] Validation Failed:", errorMessages);
+        return res.status(400).json({
+            success: false,
+            data: false,
+            error: errorMessages,
+        });
+    }
+    next();
+};
 
+const validateForgotPassword = (req, res, next) => {
     const data = req.body;
-
     const schema = Joi.object({
         phone: Joi.string().required(),
-        rememberMe: Joi.boolean(),
-        forgotPassword: Joi.boolean()
+        userType: Joi.string().valid("admin", "teacher").required(),
     });
 
     const { error } = schema.validate(data, { abortEarly: false });
-
     if (error) {
-        // Log exactly why it failed
         const errorMessages = error.details.map((i) => i.message);
-        console.log("[validateGetOtp] Validation Failed:", errorMessages);
-
+        console.log("[validateForgotPassword] Validation Failed:", errorMessages);
         return res.status(400).json({
             success: false,
             data: false,
@@ -29,21 +32,16 @@ const validateGetOtp = (req, res, next) => {
         });
     }
 
-    console.log("[validateGetOtp] Validation Passed");
     next();
 };
 
 const validateOtp = (req, res, next) => {
-    // --- LOGS START ---
-    console.log("\n[validateOtp] Incoming Request:");
-    console.log("Body (Payload):", req.body);
-    // --- LOGS END ---
-
     const data = req.body;
 
     const schema = Joi.object({
         phone: Joi.string().required(),
-        otp: Joi.string(),
+        userType: Joi.string().valid("admin", "teacher").required(),
+        otp: Joi.string().required(),
         rememberMe: Joi.boolean(),
     });
 
@@ -65,5 +63,6 @@ const validateOtp = (req, res, next) => {
 
 module.exports = {
     validateOtp,
-    validateGetOtp
+    validateForgotPassword,
+    validateUserTypes
 };

--- a/shiksha-website/shiksha-frontend/src/app/auth/sign-in.service.ts
+++ b/shiksha-website/shiksha-frontend/src/app/auth/sign-in.service.ts
@@ -10,43 +10,28 @@ import { applicationUsers } from '../shared/utility/enum.util';
 export class SignInService extends BaseRestService {
   baseUrl = environment.apiUrl;
 
-  /**
-   * Class constructor
-   * @param http 
-   */
   constructor(http: HttpClient) {
     super(http);
     this.setUri('auth');
   }
 
-  /**
-   * send the phone number to validate
-   * Backend auto-detects user type (Admin or Teacher) from phone number
-   * @param mobile_number
-   * @returns
-   */
-  validateMobileNumber(reqBody: any) {
-    return this.post(`get-otp`, reqBody);
+  getUserTypes(phone: string) {
+    return this.get(`user-types`, new HttpParams().append("phone", phone));
   }
 
-  /**
-   * validate the otp values
-   * Backend auto-detects user type (Admin or Teacher) from phone number
-   * @param otpval
-   * @param phoneNumber
-   * @returns
-   */
-  validateOTP(otpval: string, phoneNumber: string) {
+  forgotPassword(reqBody: any) {
+    return this.post(`forgot-password`, reqBody);
+  }
+
+  validateOTP(otpval: string, phoneNumber: string, userType: applicationUsers, rememberMe: boolean) {
     return this.post(`validate-otp`, {
       phone: phoneNumber,
+      userType: userType,
       otp: otpval,
+      rememberMe: rememberMe,
     });
   }
 
-  /**
-   * Auth me
-   * @returns 
-   */
   authMe() {
     return this.get('me');
   }

--- a/shiksha-website/shiksha-frontend/src/app/auth/sign-in/sign-in.component.html
+++ b/shiksha-website/shiksha-frontend/src/app/auth/sign-in/sign-in.component.html
@@ -81,15 +81,15 @@
 					<ng-otp-input (onInputChange)="handeOtpChange($event)" [config]="otpInputConfig" #ngotp
 						[ngClass]="{'error':invalidOtp}"></ng-otp-input>
 				</div>
-				<button class="btn-success font-normal text-sm md:text-lg  text-center w-full" (click)="onVerifyOTP()"
-					[disabled]="otpValue.length!=4"> Verify</button>
-				<ng-container *ngIf="otpTriggered">
-					<a class="text-success underline cursor-pointer md:text-lg text-sm" (click)="onResendOTP()">Resend
-						PIN</a>
-					<!-- <p class="timer" *ngIf="!showResendOTP">{{otpTimer | timeformat }}</p> -->
-				</ng-container>
-				<a class="text-success underline cursor-pointer md:text-lg text-sm" *ngIf="!otpTriggered"
-					(click)="forgotPin()">Forgot PIN</a>
+				<div *ngIf="userTypes.includes(applicationUsersType.ADMIN)" class="w-full flex flex-col gap-0">
+					<button class="btn-success font-normal text-sm md:text-lg text-center w-full" (click)="onVerifyOTP(applicationUsersType.ADMIN)" [disabled]="otpValue.length!=4">Login as Admin</button>
+					<a *ngIf="!otpTriggered" class="text-success underline cursor-pointer text-sm text-center" (click)="forgotPin(applicationUsersType.ADMIN)">Forgot Admin PIN</a>
+				</div>
+				<div *ngIf="userTypes.includes(applicationUsersType.TEACHER)" class="w-full flex flex-col gap-0">
+					<button class="btn-success font-normal text-sm md:text-lg text-center w-full" (click)="onVerifyOTP(applicationUsersType.TEACHER)" [disabled]="otpValue.length!=4">Login as Teacher</button>
+					<a *ngIf="!otpTriggered" class="text-success underline cursor-pointer text-sm text-center" (click)="forgotPin(applicationUsersType.TEACHER)">Forgot Teacher PIN</a>
+				</div>
+				<a *ngIf="otpTriggered" class="text-success underline cursor-pointer text-sm block mt-2 text-center" (click)="onResendOTP()">Resend PIN</a>
 				<p class="text-content font-normal text-sm text-center">Having trouble accessing application?
 					<br>Contact Sikshana Representative</p>
 			</div>

--- a/shiksha-website/shiksha-frontend/src/app/auth/sign-in/sign-in.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/auth/sign-in/sign-in.component.ts
@@ -34,6 +34,8 @@ export class SignInComponent implements OnInit,AfterViewInit, OnDestroy {
   rememberMe= false;
   storedUserInfo:any;
   otpTriggered = false;
+  userTypes: applicationUsers[] = [];
+  selectedUserType: applicationUsers | null = null;
 
   otpInputConfig: NgOtpInputConfig = {
     length: 4,
@@ -199,27 +201,38 @@ export class SignInComponent implements OnInit,AfterViewInit, OnDestroy {
       this.numberErrorMsg = 'Invalid phone number.';
     } else {
       this.numberErrorMsg = null;
-      const reqBody = {
-        phone:this.phoneNumber,
-        rememberMe:this.rememberMe
-      }
-     this.getOtp(reqBody);
-      
+      this.service.getUserTypes(this.phoneNumber).subscribe({
+        next: (res: any) => {
+          this.userTypes = res.data;
+          if (!this.userTypes.length) {
+            this.numberErrorMsg = 'Account does not exist.';
+            return;
+          }
+
+          this.selectedUserType = null;
+          this.otpTriggered = false;
+          this.modalStatus = true;
+          this.showResendOTP = false;
+          this.clearOTPFiled();
+          if(this.storedUserInfo && this.phoneNumber === this.storedUserInfo?.phone){
+            this.ngOtp.setValue(this.storedUserInfo.apin)
+          }
+        },
+        error: (err: any) => this.utility.handleError(err)
+      });
     }
   }
 
-  getOtp(reqBody:any){
-    this.service.validateMobileNumber(reqBody).subscribe({
+  forgotPin(userType: applicationUsers){
+    this.service.forgotPassword({ phone: this.phoneNumber, userType: userType }).subscribe({
       next: (res: any) => {
         this.otpTriggered = res?.data?.otpTriggered;
+        this.selectedUserType = userType;
         this.modalStatus = true;
         this.showResendOTP = false;
         this.clearOTPFiled();
         // this.startTimer();
         this.utility.showSuccess(this.otpTriggered ? 'Please enter the PIN sent to your phone number to continue' : 'Please enter your access PIN');
-        if(this.storedUserInfo && this.phoneNumber === this.storedUserInfo?.phone){
-          this.ngOtp.setValue(this.storedUserInfo.apin)
-        }
       },
       error: (err: any) => {
         this.utility.handleError(err);
@@ -227,27 +240,16 @@ export class SignInComponent implements OnInit,AfterViewInit, OnDestroy {
     });
   }
 
-  forgotPin(){
-    const reqBody = {
-      phone:this.phoneNumber,
-      rememberMe:this.rememberMe,
-      forgotPassword:true
-    }
-    this.clearOTPFiled();
-    this.secureCookieService.deleteCookie("userInfo");
-    this.storedUserInfo=null;
-   this.getOtp(reqBody);
-  }
-
   /**
    * update the loader and navigate the user on correct otp
    */
-  onVerifyOTP() {
+  onVerifyOTP(userType: applicationUsers) {
     if (this.otpValue) {
       this.service
-        .validateOTP(this.otpValue, this.phoneNumber.toString())
+        .validateOTP(this.otpValue, this.phoneNumber.toString(), userType, this.rememberMe)
         .subscribe({
           next: (res: any) => {
+            this.selectedUserType = userType;
             this.invalidOtp = false;
             this.utility.showSuccess("You've successfully logged in.");
             localStorage.setItem('token', res.data.token);
@@ -311,10 +313,15 @@ export class SignInComponent implements OnInit,AfterViewInit, OnDestroy {
   }
 
   onResendOTP() {
+    const selectedUserType = this.selectedUserType;
+    if (!selectedUserType) {
+      return; // this should never happen
+    }
+
     this.showResendOTP = false;
     // this.startTimer();
     this.clearOTPFiled();
-    this.forgotPin();
+    this.forgotPin(selectedUserType);
   }
 
   clearErrorMsg() {

--- a/shiksha-website/shiksha-frontend/src/environments/environment.uat.ts
+++ b/shiksha-website/shiksha-frontend/src/environments/environment.uat.ts
@@ -1,0 +1,6 @@
+export const environment = {
+    production:false,
+    apiUrl:'your_backend_url',
+    CRYPTO_SECRET:'your_crypto_secret',
+    EXP_MONTH: 3
+};


### PR DESCRIPTION
## Summary
PR https://github.com/A4i-tech/Shiksha-Copilot/pull/16 streamlined admin and teacher login panels into one, leading by assumption that a phone number either falls in userDao or adminDao. Apparently the admin panel lets you create teacher profiles for phone numbers in use by admins.

## Changes
- add a `GET /auth/user-types` whereby frontend can present roles as choices if there's two to pick from.
- replaced `POST /auth/get-otp` with `POST /auth/forgot-password`
  get-otp validated user existence, but also performed forgot-pin flow (unclear responsibility?). figured extracting out a new endpoint would clear up the confusion. also there already is an `/auth/validate-otp` endpoint which does everything `/auth/get-otp` did without the forgot-pin flow.

The good stuff: still takes just as many mouse clicks as before to complete the login flow.

| Before | After (single user) | After (dual user) |
|----------------------|----------------------|-----------------------------|
| ![](https://github.com/user-attachments/assets/eae9bf2e-a00c-4864-970f-6d8173541cad) | ![](https://github.com/user-attachments/assets/02f745d1-5f0f-46a8-b2e2-ad15160b5a65) | ![](https://github.com/user-attachments/assets/a8099aac-d0a1-4a23-a669-157e64178610) |