### PR TITLE
backend: introduce /health-api

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -151,7 +151,7 @@ jobs:
             echo "--- Attempt $i/30 ---"
             check_build "Frontend" "$FRONTEND_URL/health.json" && \
             check_build "Backend"  "$BACKEND_URL/health"      && \
-            check_build "API"      "$API_URL/health"          && \
+            check_build "API"      "$BACKEND_URL/health-api"  && \
             { echo "All services on build $EXPECTED_BUILD"; exit 0; }
             sleep 15 & wait $!
           done

--- a/shiksha-website/shiksha-backend/routes/system.routes.js
+++ b/shiksha-website/shiksha-backend/routes/system.routes.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const { createProxyMiddleware } = require("http-proxy-middleware");
 const router = express.Router();
 
 router.get("/", (req, res) => res.send("Shikshana Backend!"));
@@ -6,6 +7,12 @@ router.get("/", (req, res) => res.send("Shikshana Backend!"));
 router.get("/health", (req, res) => res.json({
 	status: "healthy",
 	build: process.env.SHIKSHA_COPILOT_BUILD || null,
+}));
+
+router.use("/health-api", createProxyMiddleware({
+  target: process.env.LLM_API_BASE_URL,
+  changeOrigin: true,
+  pathRewrite: () => "/health",
 }));
 
 module.exports = router;

--- a/shiksha-website/shiksha-backend/routes/system.routes.js
+++ b/shiksha-website/shiksha-backend/routes/system.routes.js
@@ -13,6 +13,11 @@ router.get("/health-api", createProxyMiddleware({
   target: process.env.LLM_API_BASE_URL,
   changeOrigin: true,
   pathRewrite: () => "/health",
+  on: {
+    error: (err, req, res) => {
+      res.status(503).json({ status: "error", message: "API unreachable" });
+    },
+  },
 }));
 
 module.exports = router;

--- a/shiksha-website/shiksha-backend/routes/system.routes.js
+++ b/shiksha-website/shiksha-backend/routes/system.routes.js
@@ -9,7 +9,7 @@ router.get("/health", (req, res) => res.json({
 	build: process.env.SHIKSHA_COPILOT_BUILD || null,
 }));
 
-router.use("/health-api", createProxyMiddleware({
+router.get("/health-api", createProxyMiddleware({
   target: process.env.LLM_API_BASE_URL,
   changeOrigin: true,
   pathRewrite: () => "/health",


### PR DESCRIPTION
shiksha-api is intended to be a private service only accessible by shiksha-backend. Health check in CI/CD invokes raw shiksha-api /health endpoint. This means shiksha-api cannot be hosted as a private service at present.

Change introduced in this PR invokes shiksha-api /health endpoint via shiksha-backend.

Using http-auth-middleware here - modern endpoints in shiksha-backend reroute requests to shiksha-api with just some middleware auth. This saves a ton on maintaining unnecessary wrapper api codes which at present exist in several qp and chatbot routes.