### PR TITLE
fix: missing prod env template

### DIFF
--- a/shiksha-website/shiksha-frontend/src/environments/environment.prod.ts
+++ b/shiksha-website/shiksha-frontend/src/environments/environment.prod.ts
@@ -1,0 +1,6 @@
+export const environment = {
+    production:true,
+    apiUrl:'your_backend_url',
+    CRYPTO_SECRET:'your_crypto_secret',
+    EXP_MONTH: 3
+};


### PR DESCRIPTION
Frontend is missing prod env template. `npm run build -- --configuration production` expects to read an `environment.prod.ts`.

This file was meant to be added in https://github.com/A4i-tech/Shiksha-Copilot/pull/69, but was filtered out by `.gitignore`: https://github.com/A4i-tech/Shiksha-Copilot/blob/e5f2d8c10d22ed7680a942961a72a637e3c6cbd9/shiksha-website/shiksha-frontend/.gitignore#L8