### PR TITLE
pptx-gen: use non-blocking io to prevent thread pinning

### DIFF
--- a/shiksha-api/app-service/app/config.py
+++ b/shiksha-api/app-service/app/config.py
@@ -64,6 +64,7 @@ class Settings(BaseSettings):
     pres_storage_filesystem: str = "file"
     pres_storage_root: str = "shiksha-copilot-presentations"
     pres_storage_options: dict[str, Any] = Field(default_factory=dict)
+    pres_download_chunk_size: PositiveInt = 1024 * 1024  # 1 MiB
     pres_upload_max_filesize: int = 5_242_880  # 5 MiB
     pres_do_transform: bool = True
 

--- a/shiksha-api/app-service/app/routers/presentation.py
+++ b/shiksha-api/app-service/app/routers/presentation.py
@@ -80,7 +80,7 @@ async def create_job(
     if not filename: raise HTTPException(status_code=400, detail="Unsupported file type (cannot read filename)")
     if textbook_file.size is None or textbook_file.size > settings.pres_upload_max_filesize: raise HTTPException(status_code=400, detail="Bad file size")
     try:
-        textbook_path, textbook_mime = await save_file_with_hash(service.storage, textbook_file, filename, ALLOWED_MIMES)
+        textbook_path, textbook_mime = await save_file_with_hash(service.storage, textbook_file, filename, ALLOWED_MIMES, settings.pres_download_chunk_size)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     return await service.jobs.create(user_id, textbook_path, textbook_mime, slides, instruction, tags)

--- a/shiksha-api/app-service/app/routers/presentation.py
+++ b/shiksha-api/app-service/app/routers/presentation.py
@@ -78,8 +78,9 @@ async def create_job(
 
     filename = textbook_file.filename
     if not filename: raise HTTPException(status_code=400, detail="Unsupported file type (cannot read filename)")
+    if textbook_file.size is None or textbook_file.size > settings.pres_upload_max_filesize: raise HTTPException(status_code=400, detail="Bad file size")
     try:
-        textbook_path, textbook_mime = await save_file_with_hash(service.storage, textbook_file, filename, content_length, ALLOWED_MIMES)
+        textbook_path, textbook_mime = await save_file_with_hash(service.storage, textbook_file, filename, ALLOWED_MIMES)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     return await service.jobs.create(user_id, textbook_path, textbook_mime, slides, instruction, tags)

--- a/shiksha-api/app-service/app/routers/presentation.py
+++ b/shiksha-api/app-service/app/routers/presentation.py
@@ -65,7 +65,7 @@ async def _ja_lock(key):
 @router.post("/job")
 async def create_job(
     user_id: XUserIDHeader,
-    content_length: int = Header(lt=settings.pres_upload_max_filesize),
+    content_length: int = Header(lt=settings.pres_upload_max_filesize),  # bail early
     textbook_file: UploadFile = File(...),
     slides: int | None = Form(None, ge=1, le=settings.pres_max_slide_count),
     instruction: str | None = Form(None, max_length=settings.pres_max_instruction_size),
@@ -78,9 +78,9 @@ async def create_job(
 
     filename = textbook_file.filename
     if not filename: raise HTTPException(status_code=400, detail="Unsupported file type (cannot read filename)")
-    if textbook_file.size is None or textbook_file.size > settings.pres_upload_max_filesize: raise HTTPException(status_code=400, detail="Bad file size")
+    if textbook_file.size is not None and textbook_file.size > settings.pres_upload_max_filesize: raise HTTPException(status_code=400, detail="Bad file size")  # bail early
     try:
-        textbook_path, textbook_mime = await save_file_with_hash(service.storage, textbook_file, filename, ALLOWED_MIMES, settings.pres_download_chunk_size)
+        textbook_path, textbook_mime = await save_file_with_hash(service.storage, textbook_file, filename, ALLOWED_MIMES, settings.pres_download_chunk_size, settings.pres_upload_max_filesize)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     return await service.jobs.create(user_id, textbook_path, textbook_mime, slides, instruction, tags)

--- a/shiksha-api/app-service/app/services/presentation/agent.py
+++ b/shiksha-api/app-service/app/services/presentation/agent.py
@@ -4,7 +4,8 @@ from datetime import datetime, timezone
 import inspect
 from io import BytesIO
 import json
-from typing import IO, Annotated, Any, Literal
+from typing import Annotated, Any, Literal
+from aiofiles.threadpool.binary import AsyncBufferedReader
 
 from app.models.presentation import CaptionerResponse, ImageSearchResults, NextSlideSpec, PresentationOutline, ShikshaAgentEvent, ShikshaCheckpointEvent, SlideSpec, WelcomeSlideInfo, YouTubeVideoResult
 from app.utils.storage import Storage
@@ -324,17 +325,17 @@ def _adapt_event(event: AgentStreamEvent) -> ShikshaAgentEvent | None:
     return None
 
 
-async def plan(textbook_path: str, textbook_mime: str, data: IO[bytes], figures: list[docparser.FigureInfo], slides: int | None, metadata: dict[str, Any], instruction: str | None):
+async def plan(textbook_path: str, textbook_mime: str, data: AsyncBufferedReader, figures: list[docparser.FigureInfo], slides: int | None, metadata: dict[str, Any], instruction: str | None):
     if "outline" in metadata:
         return
 
     yield ShikshaCheckpointEvent(message="Reading document to build presentation spec...")
 
-    data.seek(0)
+    await data.seek(0)
     if textbook_mime.startswith("text/"):
-        f = TextContent(data.read().decode(), metadata={"source": textbook_path})
+        f = TextContent((await data.read()).decode(), metadata={"source": textbook_path})
     else:
-        f = BinaryContent(data.read(), media_type=textbook_mime)
+        f = BinaryContent(await data.read(), media_type=textbook_mime)
 
     outline = None
     async for raw_event in planner.run_stream_events([f, PLANNER_USER_PROMPT.safe_substitute(
@@ -361,7 +362,7 @@ async def plan(textbook_path: str, textbook_mime: str, data: IO[bytes], figures:
     )
 
 
-async def design(storage: Storage, prs: presentation.Presentation, data: IO[bytes], figures_dir: str, outline: PresentationOutline, metadata: dict[str, Any], instruction: str | None):
+async def design(storage: Storage, prs: presentation.Presentation, data: AsyncBufferedReader, figures_dir: str, outline: PresentationOutline, metadata: dict[str, Any], instruction: str | None):
     # Initialize metadata
     if "slides_completed" not in metadata: metadata["slides_completed"] = []
     if "slides_created" not in metadata: metadata["slides_created"] = 0

--- a/shiksha-api/app-service/app/services/presentation/docparser.py
+++ b/shiksha-api/app-service/app/services/presentation/docparser.py
@@ -78,7 +78,7 @@ async def _actually_read_figures(storage: Storage, textbook: AsyncBufferedReader
 
     await textbook.seek(0)
     try:
-        doc = pymupdf.open(stream=await textbook.read())
+        doc = await asyncio.to_thread(pymupdf.open, stream=await textbook.read())
     except pymupdf.FileDataError:
         return []
 
@@ -110,11 +110,15 @@ async def read_figures(storage: Storage, textbook: AsyncBufferedReader, out_dir:
     return figures
 
 
+def _to_markdown(data: bytes) -> str:
+    with pymupdf.open(stream=data) as doc:
+        return pymupdf4llm.to_markdown(doc)
+
+
 async def _transform(content: AsyncBufferedReader, mime: str) -> str | None:
     if mime == "application/pdf":
         await content.seek(0)
-        with pymupdf.open(stream=await content.read()) as doc:
-            return await asyncio.to_thread(pymupdf4llm.to_markdown, doc)
+        return await asyncio.to_thread(_to_markdown, await content.read())
     return None
 
 

--- a/shiksha-api/app-service/app/services/presentation/docparser.py
+++ b/shiksha-api/app-service/app/services/presentation/docparser.py
@@ -109,18 +109,18 @@ async def read_figures(storage: Storage, textbook: IO[bytes], out_dir: str, capt
     return figures
 
 
-def _transform(textbook_filename: str, textbook: IO[bytes]) -> str | None:
-    if pathlib.Path(textbook_filename).suffix == ".pdf":
-        textbook.seek(0)
-        with pymupdf.open(stream=textbook, filetype="pdf") as doc:
+def _transform(content: IO[bytes], mime: str) -> str | None:
+    if mime == "application/pdf":
+        content.seek(0)
+        with pymupdf.open(stream=content, filetype="pdf") as doc:
             return pymupdf4llm.to_markdown(doc)
     return None
 
 
-async def transform(storage: Storage, textbook_filename: str, textbook: IO[bytes], out_path: str) -> str | None:
+async def transform(storage: Storage, content: IO[bytes], mime: str, out_path: str) -> str | None:
     storage_path = out_path + ".md"
     if not await storage.exists(storage_path):
-        markdown = await asyncio.to_thread(_transform, textbook_filename, textbook)
+        markdown = await asyncio.to_thread(_transform, content, mime)
         if markdown is None:
             return None
         await storage.write_text(storage_path, markdown)

--- a/shiksha-api/app-service/app/services/presentation/docparser.py
+++ b/shiksha-api/app-service/app/services/presentation/docparser.py
@@ -77,7 +77,7 @@ async def _actually_read_figures(storage: Storage, textbook: IO[bytes], out_dir:
 
     textbook.seek(0)
     try:
-        doc = pymupdf.open(textbook)
+        doc = pymupdf.open(stream=textbook)
     except pymupdf.FileDataError:
         return []
 
@@ -112,7 +112,8 @@ async def read_figures(storage: Storage, textbook: IO[bytes], out_dir: str, capt
 def _transform(textbook_filename: str, textbook: IO[bytes]) -> str | None:
     if pathlib.Path(textbook_filename).suffix == ".pdf":
         textbook.seek(0)
-        return pymupdf4llm.to_markdown(textbook)
+        with pymupdf.open(stream=textbook, filetype="pdf") as doc:
+            return pymupdf4llm.to_markdown(doc)
     return None
 
 

--- a/shiksha-api/app-service/app/services/presentation/docparser.py
+++ b/shiksha-api/app-service/app/services/presentation/docparser.py
@@ -13,6 +13,7 @@ from pptx.enum.shapes import PP_PLACEHOLDER
 from pydantic_ai import AgentRunError, BinaryContent
 import pymupdf4llm
 import pymupdf
+from aiofiles.threadpool.binary import AsyncBufferedReader
 
 
 async def _caption(data: IO[bytes], figure_path: str, page_text: str, sem: asyncio.Semaphore) -> FigureInfo | None:
@@ -61,7 +62,7 @@ def _page_figures(doc: pymupdf.Document, page: pymupdf.Page) -> Iterator[tuple[i
     return page, result
 
 
-async def _actually_read_figures(storage: Storage, textbook: IO[bytes], out_dir: str, caption_concurrency: int) -> list[FigureInfo]:
+async def _actually_read_figures(storage: Storage, textbook: AsyncBufferedReader, out_dir: str, caption_concurrency: int) -> list[FigureInfo]:
     logger = logging.getLogger(__name__)
     sem = asyncio.Semaphore(caption_concurrency)
     tasks: list[asyncio.Task[FigureInfo | None]] = []
@@ -75,9 +76,9 @@ async def _actually_read_figures(storage: Storage, textbook: IO[bytes], out_dir:
         await storage.write_bytes(storage_path, data.getvalue())
         return await _caption(data, figure_name, page_text, sem)
 
-    textbook.seek(0)
+    await textbook.seek(0)
     try:
-        doc = pymupdf.open(stream=textbook)
+        doc = pymupdf.open(stream=await textbook.read())
     except pymupdf.FileDataError:
         return []
 
@@ -99,7 +100,7 @@ async def _actually_read_figures(storage: Storage, textbook: IO[bytes], out_dir:
     return [f for f in figures if f is not None]
 
 
-async def read_figures(storage: Storage, textbook: IO[bytes], out_dir: str, caption_concurrency: int = 5) -> list[FigureInfo]:
+async def read_figures(storage: Storage, textbook: AsyncBufferedReader, out_dir: str, caption_concurrency: int = 5) -> list[FigureInfo]:
     storage_mf_path = storage.path(out_dir, "manifest.json")
     if await storage.exists(storage_mf_path):
         return list(map(FigureInfo.model_validate, json.loads(await storage.read_text(storage_mf_path))))
@@ -109,18 +110,18 @@ async def read_figures(storage: Storage, textbook: IO[bytes], out_dir: str, capt
     return figures
 
 
-def _transform(content: IO[bytes], mime: str) -> str | None:
+async def _transform(content: AsyncBufferedReader, mime: str) -> str | None:
     if mime == "application/pdf":
-        content.seek(0)
-        with pymupdf.open(stream=content, filetype="pdf") as doc:
-            return pymupdf4llm.to_markdown(doc)
+        await content.seek(0)
+        with pymupdf.open(stream=await content.read()) as doc:
+            return await asyncio.to_thread(pymupdf4llm.to_markdown, doc)
     return None
 
 
-async def transform(storage: Storage, content: IO[bytes], mime: str, out_path: str) -> str | None:
+async def transform(storage: Storage, content: AsyncBufferedReader, mime: str, out_path: str) -> str | None:
     storage_path = out_path + ".md"
     if not await storage.exists(storage_path):
-        markdown = await asyncio.to_thread(_transform, content, mime)
+        markdown = await _transform(content, mime)
         if markdown is None:
             return None
         await storage.write_text(storage_path, markdown)

--- a/shiksha-api/app-service/app/services/presentation/service.py
+++ b/shiksha-api/app-service/app/services/presentation/service.py
@@ -129,10 +129,8 @@ class PresentationService:
         elif job.status == "extracting_figures":
             await self.jobs.update(job.id, {"message": "Reading textbook and extracting figures"})
             stem = pathlib.Path(job.textbook_file).stem
-            async with self.planner_sem:
-                async with self.storage.read(self.storage.path("uploads", job.textbook_file)) as f:
-                    contents = io.BytesIO(await f.read())
-                figures = await docparser.read_figures(self.storage, contents, self.storage.path("out", stem, "figures"))
+            async with self.planner_sem, self.storage.read(self.storage.path("uploads", job.textbook_file)) as f:
+                figures = await docparser.read_figures(self.storage, f, self.storage.path("out", stem, "figures"))
                 await self.jobs.update(job.id, {"metadata.analysis": {
                     "extraction_time": datetime.now().isoformat(),
                     "figures": list(map(lambda x: x.model_dump(), figures)),
@@ -141,7 +139,7 @@ class PresentationService:
                     await self.jobs.update(job.id, {"message": "Simplifying document"})
                     # we are deliberately storing transformation in out/stem/stem instead of out/stem/jobid - if we had
                     # computed transformation for this document during another job, we can skip recomputing for this job.
-                    transform_path = await docparser.transform(self.storage, contents, job.textbook_mime, self.storage.path("out", stem, stem))
+                    transform_path = await docparser.transform(self.storage, f, job.textbook_mime, self.storage.path("out", stem, stem))
                     await self.jobs.update(job.id, {"metadata.transform_path": transform_path})
             await self.jobs.update(job.id, {"status": "planning_structure"})
         elif job.status == "planning_structure":
@@ -158,11 +156,9 @@ class PresentationService:
             else:
                 source_path = self.storage.path("uploads", job.textbook_file)
                 source_mime = job.textbook_mime
-            async with self.planner_sem:
-                async with self.storage.read(source_path) as f:
-                    contents = io.BytesIO(await f.read())
-                figures = await docparser.read_figures(self.storage, contents, self.storage.path("out", stem, "figures"))
-                async for event in agent.plan(source_path, source_mime, contents, figures, job.slides, metadata, job.instruction):
+            async with self.planner_sem, self.storage.read(source_path) as f:
+                figures = await docparser.read_figures(self.storage, f, self.storage.path("out", stem, "figures"))
+                async for event in agent.plan(source_path, source_mime, f, figures, job.slides, metadata, job.instruction):
                     if isinstance(event, agent.ShikshaCheckpointEvent):
                         await self._process_checkpoint(job, event, "plan", None, out_path)
                     else:
@@ -190,10 +186,8 @@ class PresentationService:
                 source_path = self.storage.path("uploads", job.textbook_file)
 
             figures_dir = self.storage.path("out", stem, "figures")
-            async with self.designer_sem:
-                async with self.storage.read(source_path) as f:
-                    contents = io.BytesIO(await f.read())
-                async for event in agent.design(self.storage, prs, contents, figures_dir, outline, metadata, job.instruction):
+            async with self.designer_sem, self.storage.read(source_path) as f:
+                async for event in agent.design(self.storage, prs, f, figures_dir, outline, metadata, job.instruction):
                     if isinstance(event, agent.ShikshaCheckpointEvent):
                         await self._process_checkpoint(job, event, "design", prs, out_path)
                     else:

--- a/shiksha-api/app-service/app/services/presentation/service.py
+++ b/shiksha-api/app-service/app/services/presentation/service.py
@@ -141,7 +141,7 @@ class PresentationService:
                     await self.jobs.update(job.id, {"message": "Simplifying document"})
                     # we are deliberately storing transformation in out/stem/stem instead of out/stem/jobid - if we had
                     # computed transformation for this document during another job, we can skip recomputing for this job.
-                    transform_path = await docparser.transform(self.storage, job.textbook_file, contents, self.storage.path("out", stem, stem))
+                    transform_path = await docparser.transform(self.storage, contents, job.textbook_mime, self.storage.path("out", stem, stem))
                     await self.jobs.update(job.id, {"metadata.transform_path": transform_path})
             await self.jobs.update(job.id, {"status": "planning_structure"})
         elif job.status == "planning_structure":

--- a/shiksha-api/app-service/app/services/presentation/service.py
+++ b/shiksha-api/app-service/app/services/presentation/service.py
@@ -1,3 +1,4 @@
+import io
 import mimetypes
 import time
 import traceback
@@ -127,9 +128,11 @@ class PresentationService:
             await self.jobs.update(job.id, {"status": "extracting_figures", "message": "Extracting figures from textbook"})
         elif job.status == "extracting_figures":
             await self.jobs.update(job.id, {"message": "Reading textbook and extracting figures"})
-            async with self.storage.read(self.storage.path("uploads", job.textbook_file)) as f:
-                stem = pathlib.Path(job.textbook_file).stem
-                figures = await docparser.read_figures(self.storage, f, self.storage.path("out", stem, "figures"))
+            stem = pathlib.Path(job.textbook_file).stem
+            async with self.planner_sem:
+                async with self.storage.read(self.storage.path("uploads", job.textbook_file)) as f:
+                    contents = io.BytesIO(await f.read())
+                figures = await docparser.read_figures(self.storage, contents, self.storage.path("out", stem, "figures"))
                 await self.jobs.update(job.id, {"metadata.analysis": {
                     "extraction_time": datetime.now().isoformat(),
                     "figures": list(map(lambda x: x.model_dump(), figures)),
@@ -138,7 +141,7 @@ class PresentationService:
                     await self.jobs.update(job.id, {"message": "Simplifying document"})
                     # we are deliberately storing transformation in out/stem/stem instead of out/stem/jobid - if we had
                     # computed transformation for this document during another job, we can skip recomputing for this job.
-                    transform_path = await docparser.transform(self.storage, job.textbook_file, f, self.storage.path("out", stem, stem))
+                    transform_path = await docparser.transform(self.storage, job.textbook_file, contents, self.storage.path("out", stem, stem))
                     await self.jobs.update(job.id, {"metadata.transform_path": transform_path})
             await self.jobs.update(job.id, {"status": "planning_structure"})
         elif job.status == "planning_structure":
@@ -155,9 +158,11 @@ class PresentationService:
             else:
                 source_path = self.storage.path("uploads", job.textbook_file)
                 source_mime = job.textbook_mime
-            async with self.planner_sem, self.storage.read(source_path) as f:
-                figures = await docparser.read_figures(self.storage, f, self.storage.path("out", stem, "figures"))
-                async for event in agent.plan(source_path, source_mime, f, figures, job.slides, metadata, job.instruction):
+            async with self.planner_sem:
+                async with self.storage.read(source_path) as f:
+                    contents = io.BytesIO(await f.read())
+                figures = await docparser.read_figures(self.storage, contents, self.storage.path("out", stem, "figures"))
+                async for event in agent.plan(source_path, source_mime, contents, figures, job.slides, metadata, job.instruction):
                     if isinstance(event, agent.ShikshaCheckpointEvent):
                         await self._process_checkpoint(job, event, "plan", None, out_path)
                     else:
@@ -172,7 +177,7 @@ class PresentationService:
                 await docparser.save_pptx(self.storage, prs, out_path)
             else:
                 async with self.storage.read(out_path) as f:
-                    prs = Presentation(f)
+                    prs = Presentation(io.BytesIO(await f.read()))
 
             outline = agent.PresentationOutline.model_validate(job.metadata["plan"]["outline"])
             metadata = job.metadata.get("design", {})
@@ -185,8 +190,10 @@ class PresentationService:
                 source_path = self.storage.path("uploads", job.textbook_file)
 
             figures_dir = self.storage.path("out", stem, "figures")
-            async with self.designer_sem, self.storage.read(source_path) as f:
-                async for event in agent.design(self.storage, prs, f, figures_dir, outline, metadata, job.instruction):
+            async with self.designer_sem:
+                async with self.storage.read(source_path) as f:
+                    contents = io.BytesIO(await f.read())
+                async for event in agent.design(self.storage, prs, contents, figures_dir, outline, metadata, job.instruction):
                     if isinstance(event, agent.ShikshaCheckpointEvent):
                         await self._process_checkpoint(job, event, "design", prs, out_path)
                     else:
@@ -203,8 +210,9 @@ class PresentationService:
             await self.jobs.update(job.id, {"message": "Adding media"})
             stem = pathlib.Path(job.textbook_file).stem
             out_path = self.storage.path("out", stem, f"{job.id}.pptx")
-            async with self.finalizer_sem, self.storage.read(out_path) as f:
-                prs = Presentation(f)
+            async with self.finalizer_sem:
+                async with self.storage.read(out_path) as f:
+                    prs = Presentation(io.BytesIO(await f.read()))
 
                 metadata = job.metadata.get("finalize", {})
                 if not isinstance(metadata, dict):
@@ -221,7 +229,7 @@ class PresentationService:
             stem = pathlib.Path(job.textbook_file).stem
             out_path = self.storage.path("out", stem, f"{job.id}.pptx")
             async with self.storage.read(out_path) as f:
-                prs = Presentation(f)
+                prs = Presentation(io.BytesIO(await f.read()))
 
                 quality_score = 1.0
                 quality_issues = []

--- a/shiksha-api/app-service/app/services/presentation/utils.py
+++ b/shiksha-api/app-service/app/services/presentation/utils.py
@@ -190,7 +190,7 @@ async def save_file_with_hash(storage: Storage, file: UploadFile, filename: str,
         await f.flush()
         await f.seek(0)
         path = pathlib.Path(str(f.name))
-        mime = magic.from_file(path, mime=True)
+        mime = await asyncio.to_thread(magic.from_file, path, mime=True)
         if mime not in allowed_mimes: raise ValueError("Unexpected mime (%s)" % mime)
 
         final_name = f"{sha256.hexdigest()}{suffix}"

--- a/shiksha-api/app-service/app/services/presentation/utils.py
+++ b/shiksha-api/app-service/app/services/presentation/utils.py
@@ -179,7 +179,7 @@ async def resolve_image(image: str, is_url: bool, storage: Storage | None = None
         return BytesIO(await resp.read())
 
 
-async def save_file_with_hash(storage: Storage, file: UploadFile, filename: str, allowed_mimes: set[str], chunk_size: int = 1024 * 1024) -> tuple[str, str]:
+async def save_file_with_hash(storage: Storage, file: UploadFile, filename: str, allowed_mimes: set[str], chunk_size: int) -> tuple[str, str]:
     suffix = pathlib.Path(filename).suffix.lower()
     sha256 = hashlib.sha256()
     async with aiofiles.tempfile.NamedTemporaryFile(suffix=suffix) as f:

--- a/shiksha-api/app-service/app/services/presentation/utils.py
+++ b/shiksha-api/app-service/app/services/presentation/utils.py
@@ -179,11 +179,15 @@ async def resolve_image(image: str, is_url: bool, storage: Storage | None = None
         return BytesIO(await resp.read())
 
 
-async def save_file_with_hash(storage: Storage, file: UploadFile, filename: str, allowed_mimes: set[str], chunk_size: int) -> tuple[str, str]:
+async def save_file_with_hash(storage: Storage, file: UploadFile, filename: str, allowed_mimes: set[str], chunk_size: int, max_size: int) -> tuple[str, str]:
     suffix = pathlib.Path(filename).suffix.lower()
     sha256 = hashlib.sha256()
+    total = 0
     async with aiofiles.tempfile.NamedTemporaryFile(suffix=suffix) as f:
         while buf := await file.read(chunk_size):
+            total += len(buf)
+            if total > max_size: raise ValueError(f"Bad file size (expected <= {max_size}, got > {total})")
+
             await f.write(buf)
             sha256.update(buf)
 

--- a/shiksha-api/app-service/app/services/presentation/utils.py
+++ b/shiksha-api/app-service/app/services/presentation/utils.py
@@ -187,6 +187,7 @@ async def save_file_with_hash(storage: Storage, file: UploadFile, filename: str,
             await f.write(buf)
             sha256.update(buf)
 
+        await f.flush()
         await f.seek(0)
         path = pathlib.Path(str(f.name))
         mime = magic.from_file(path, mime=True)

--- a/shiksha-api/app-service/app/services/presentation/utils.py
+++ b/shiksha-api/app-service/app/services/presentation/utils.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import tempfile
 from typing import IO, Literal
+import aiofiles
 import aiohttp
 import pathlib
 from app.config import settings
@@ -178,26 +179,22 @@ async def resolve_image(image: str, is_url: bool, storage: Storage | None = None
         return BytesIO(await resp.read())
 
 
-async def save_file_with_hash(storage: Storage, file: UploadFile, filename: str, n: int, allowed_mimes: set[str]) -> tuple[str, str]:
+async def save_file_with_hash(storage: Storage, file: UploadFile, filename: str, allowed_mimes: set[str], chunk_size: int = 1024 * 1024) -> tuple[str, str]:
     suffix = pathlib.Path(filename).suffix.lower()
     sha256 = hashlib.sha256()
-    with tempfile.NamedTemporaryFile(suffix=suffix) as f:
-        pending = n
-        while chunk := await file.read(min(pending, 8192)):
-            f.write(chunk)
-            sha256.update(chunk)
-            pending -= len(chunk)
-            if pending == 0:
-                break
+    async with aiofiles.tempfile.NamedTemporaryFile(suffix=suffix) as f:
+        while buf := await file.read(chunk_size):
+            await f.write(buf)
+            sha256.update(buf)
 
-        f.seek(0)
-        mime = magic.from_file(f.name, mime=True)
-        if mime not in allowed_mimes:
-            raise ValueError("Unexpected mime (%s)" % mime)
+        await f.seek(0)
+        path = pathlib.Path(str(f.name))
+        mime = magic.from_file(path, mime=True)
+        if mime not in allowed_mimes: raise ValueError("Unexpected mime (%s)" % mime)
 
-        f.seek(0)
         final_name = f"{sha256.hexdigest()}{suffix}"
-        await storage.write_bytes(storage.path("uploads", final_name), pathlib.Path(f.name))
+        await f.seek(0)
+        await storage.write_bytes(storage.path("uploads", final_name), path)
     return final_name, mime
 
 

--- a/shiksha-api/app-service/app/utils/storage.py
+++ b/shiksha-api/app-service/app/utils/storage.py
@@ -1,11 +1,12 @@
 import pathlib
 import posixpath
-import tempfile
 from contextlib import asynccontextmanager
-from typing import IO, Any, AsyncIterator
+from typing import Any, AsyncIterator
 
+import aiofiles
 import fsspec
 from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
+from aiofiles.threadpool.binary import AsyncBufferedReader
 
 
 class Storage:
@@ -41,8 +42,8 @@ class Storage:
 
 
     @asynccontextmanager
-    async def read(self, path: str) -> AsyncIterator[IO[bytes]]:
-        with tempfile.NamedTemporaryFile(suffix=pathlib.Path(path).suffix) as f:
+    async def read(self, path: str) -> AsyncIterator[AsyncBufferedReader]:
+        async with aiofiles.tempfile.NamedTemporaryFile(suffix=pathlib.Path(path).suffix) as f:
             await self.fs._get_file(posixpath.join(self.root, path), f.name)
-            f.seek(0)
-            yield f.file
+            await f.seek(0)
+            yield f


### PR DESCRIPTION
## Introduction
Every time the presentation pipeline read or wrote file, it froze the entire server (not "slowed down" - froze). One large textbook upload was enough to stall every other job waiting in the queue because the event loop was stuck babysitting a file read.

This only surfaced in prod testing because shiksha-api is hosted on a low-resource server (1 vCPU). A single-processor server should still be sufficient to run many pptx-gen tasks concurrently, because most time is spent waiting on I/O - reading files from disk, downloading content from storage, writing output - rather than actually computing.

## Changes
Changes in this PR addresses the issue using aiofiles:
- freads, fwrites no longer block evloop - every seek(), read() call is awaited via aiofiles
- file download chunk size increased from 8192 bytes to 1MiB to reduce await cycles needed to read large files
  - remember we are working with (primarily) PDFs here - 8192 is far too conservative that it is actually COUNTERINTUITIVE. for a 5mib file, we are talking 640 await cycles now down to 5.
  - [starlette sets spool_max_size of 1MiB](https://github.com/Kludex/starlette/blob/fa5355442753f794965ae1af0f87f9fec1b9a3de/starlette/formparsers.py#L126) so any chunk size lesser than 1MiB is virtually ineffective in offloading any memory usage.
- figure extraction now correctly acquires planner lock before reading the file
- libraries that require sync file objects (pymupdf, python-pptx) are still handed io.BytesIO(await f.read()) instead of the async file directly - but these libraries do not support asyncbufferedstream nor any protocol types that could fill the gap here, but this is still a major improvement - even if we are still loading the entire file in memory during these ops, we are retrieving the file without pinning the evloop.