### PR TITLE
cicd: move deployment from azure-blob to azure-swa

### DIFF
--- a/.github/workflows/cicd-frontend.yaml
+++ b/.github/workflows/cicd-frontend.yaml
@@ -17,18 +17,13 @@ on:
         required: true
         type: string
       deploy_target:
-        description: "Deployment target: 'github-pages' or 'azure-blob'. Leave blank to skip deployment."
+        description: "Deployment target: 'github-pages' or 'azure-swa'. Leave blank to skip deployment."
         required: false
         type: string
         default: ""
-      azure_blob_container:
-        description: "Azure Blob Storage container name (defaults to '$web' for static websites)"
-        required: false
-        type: string
-        default: "$web"
     secrets:
-      azure_connection_string:
-        description: "Azure Storage connection string (required when deploy_target is 'azure-blob')"
+      AZURE_STATIC_WEB_APPS_API_TOKEN:
+        description: "Azure static web app deployment token (required when deploy_target is 'azure-swa')"
         required: false
     outputs:
       page_url:
@@ -53,10 +48,10 @@ jobs:
 
     environment:
       name: ${{ inputs.deploy_target != '' && inputs.deploy_name || '' }}
-      url: ${{ inputs.deploy_target != '' && steps.deployment.outputs.page_url || '' }}
+      url: ${{ steps.deployment.outputs.page_url || steps.deploy-azure-swa.outputs.static_web_app_url || '' }}
 
     outputs:
-      page_url: ${{ steps.deployment.outputs.page_url || steps.set-azure-url.outputs.page_url }}
+      page_url: ${{ steps.deployment.outputs.page_url || steps.deploy-azure-swa.outputs.static_web_app_url }}
 
     env:
       BACKEND_URL: ${{ inputs.api_url }}
@@ -100,17 +95,13 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
 
-      - name: Deploy to Azure Blob Storage
-        if: inputs.deploy_target == 'azure-blob'
-        uses: LanceMcCarthy/Action-AzureBlobUpload@v3
+      - name: Deploy to Azure Static Web App
+        id: deploy-azure-swa
+        if: inputs.deploy_target == 'azure-swa'
+        uses: Azure/static-web-apps-deploy@v1
         with:
-          connection_string: ${{ secrets.azure_connection_string }}
-          container_name: ${{ inputs.azure_blob_container }}
-          source_folder: shiksha-website/shiksha-frontend/dist/shiksha-frontend
-          clean_destination_folder: true
-          delete_if_exists: true
-
-      - name: Set Azure page URL output
-        if: inputs.deploy_target == 'azure-blob'
-        id: set-azure-url
-        run: echo "page_url=${{ vars.AZURE_FRONTEND_URL }}" >> $GITHUB_OUTPUT
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          action: upload
+          app_location: shiksha-website/shiksha-frontend/dist/shiksha-frontend
+          skip_app_build: true
+          output_location: ""

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -88,10 +88,10 @@ jobs:
     needs: cd-backend-prod
     uses: ./.github/workflows/cicd-frontend.yaml
     secrets:
-      azure_connection_string: ${{ secrets.AZURE_CONNECTION_STRING_FRONTEND }}
+      AZURE_STATIC_WEB_APPS_API_TOKEN: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
     with:
       deploy_name: shiksha-frontend-prod
-      deploy_target: ${{ github.event_name == 'push' && github.ref_name == 'a4i/main' && 'azure-blob' || '' }}
+      deploy_target: ${{ github.event_name == 'push' && github.ref_name == 'a4i/main' && 'azure-swa' || '' }}
       environment: production
       api_url: ${{ needs.cd-backend-prod.result == 'success' && format('{0}/api', needs.cd-backend-prod.outputs['service-url']) || '' }}
 


### PR DESCRIPTION
## Summary
While you _could_ repurpose an Azure Blob Storage Account to host a static web app, Azure Static Web Apps is the better shout here.

SWA hands you a `stableInboundIP` (an actual IPv4 address) alongside the usual <label>.azurestaticapps.net URL. That is a lifesaver if you are stuck with a registrar like GoDaddy that still hasn't got round to supporting CNAME flattening. Since they only accept an A record at the apex and won't budge, having an actual IPv4 sorts us right out.

Best part is, SWA along with the apex record setup is entirely free of cost.

This workflow has been tested on a fork: https://github.com/mamuqsit/Shiksha-Copilot/actions/runs/26498678126/job/78033807490

## Follow up tasks
- Drop repo secret `AZURE_CONNECTION_STRING_FRONTEND`, `AZURE_FRONTEND_URL`
- Configure repo secret `AZURE_STATIC_WEB_APPS_API_TOKEN` to SWA deployment token