### PR TITLE
qp: introduce image support

### DIFF
--- a/shiksha-api/app-service/app/models/question_paper.py
+++ b/shiksha-api/app-service/app/models/question_paper.py
@@ -43,7 +43,7 @@ SerializableBytes = Annotated[
 
 
 class Content(BaseModel):
-    content_type: Literal["text/plain", "image/png"] = Field(default="text/plain")
+    content_type: Literal["text/plain", "image/png", "image/jpeg"] = Field(default="text/plain")
     content: SerializableBytes
 
     @staticmethod

--- a/shiksha-api/app-service/app/models/question_paper.py
+++ b/shiksha-api/app-service/app/models/question_paper.py
@@ -3,8 +3,7 @@
 
 from enum import Enum
 from typing import Annotated, List, Literal, Optional, TypeAlias
-import re
-from pydantic import AfterValidator, BaseModel, field_validator, Field, model_validator
+from pydantic import AfterValidator, BaseModel, BeforeValidator, Field, WithJsonSchema
 
 
 # ==============================
@@ -36,11 +35,25 @@ Marking = Annotated[
     AfterValidator(valid_marking)
 ]
 
+SerializableBytes = Annotated[
+    bytes,
+    BeforeValidator(lambda v: v if isinstance(v, bytes) else v.encode("utf-8")),
+    WithJsonSchema({"type": "string"}),
+]
+
+
+class Content(BaseModel):
+    content_type: Literal["text/plain", "image/png"] = Field(default="text/plain")
+    content: SerializableBytes
+
+    @staticmethod
+    def text(content: str): return Content(content=content.encode(encoding="utf-8"))
+
 
 class TextQuestion(BaseModel):
-    question: str = Field(default="")
-    answer: str = Field(default="")
-    keyAnswer: str = Field(default="", description="\n".join([
+    question: list[Content] = Field(default_factory=list)
+    answer: list[Content] = Field(default_factory=list)
+    keyAnswer: list[Content] = Field(default_factory=list, description="\n".join([
         "Answer to be displayed right below the question.",
         "- For MCQs, this should be the label of the correct option (e.g. 'A').",
         "- For fill-in-the-blank questions, this should be the word or phrase that fills the blank.",
@@ -49,71 +62,22 @@ class TextQuestion(BaseModel):
     difficulty: DifficultyType = "Average"
 
 
-
 class McqOption(BaseModel):
     label: str
-    text: str
-
+    text: list[Content]
 
 
 class FourOptionsQuestion(BaseModel):
-    question: str = Field(default="", examples=["What is the speed of light in vacuum?"])
+    question: list[Content] = Field(default_factory=list, examples=["What is the speed of light in vacuum?"])
     options: List[McqOption] = Field(default_factory=list, min_length=4, max_length=4, examples=[[
-        McqOption(label="A", text="3x10^8 m/s"),
-        McqOption(label="B", text="3x10^6 m/s"),
-        McqOption(label="C", text="3x10^10 m/s"),
-        McqOption(label="D", text="3x10^5 m/s")
+        McqOption(label="A", text=[Content.text("3x10^8 m/s")]),
+        McqOption(label="B", text=[Content.text("3x10^6 m/s")]),
+        McqOption(label="C", text=[Content.text("3x10^10 m/s")]),
+        McqOption(label="D", text=[Content.text("3x10^5 m/s")])
     ]])
-    answer: str = Field(default="", examples=["3x10^8 m/s"])
-    keyAnswer: str = Field(default="", description="The correct answer choice. This is displayed right below the question.", examples=["A"])
+    answer: list[Content] = Field(default_factory=list, examples=["3x10^8 m/s"])
+    keyAnswer: list[Content] = Field(default_factory=list, description="The correct answer choice. This is displayed right below the question.", examples=["A"])
     difficulty: DifficultyType = "Average"
-
-    @model_validator(mode="before")
-    @classmethod
-    def convert_legacy_mcq_shape(cls, values):
-        if not isinstance(values, dict):
-            return values
-
-        values = dict(values)
-
-        if "options" not in values:
-            legacy_options = []
-            for label in ["A", "B", "C", "D", "E", "F"]:
-                option_key = f"option_{label.lower()}"
-                option_text = values.get(option_key)
-                if option_text:
-                    legacy_options.append({"label": label, "text": option_text})
-
-            if legacy_options:
-                values["options"] = legacy_options
-
-        if "keyAnswer" not in values and "correct_option" in values:
-            correct_option = values.get("correct_option")
-            if isinstance(correct_option, str):
-                match = re.match(r"option_([A-Za-z])$", correct_option.strip())
-                values["keyAnswer"] = (
-                    match.group(1).upper() if match else correct_option.strip()
-                )
-
-        return values
-
-    @field_validator("options", mode="before")
-    def convert_strings_to_options(cls, v):
-        # If it's a list of strings, convert to McqOption objects
-        if v is None:
-            return []
-        if isinstance(v, list) and len(v) > 0 and isinstance(v[0], str):
-            labels = ["A", "B", "C", "D", "E", "F"]
-            cleaned_options = []
-            for i, opt in enumerate(v):
-                # Clean prefix like "A. ", "a) ", "1. " from the start of the string
-                clean_text = re.sub(r'^[A-Za-z0-9]+[\.\)]\s*', '', opt)
-                
-                label = labels[i] if i < len(labels) else str(i+1)
-                cleaned_options.append({"label": label, "text": clean_text})
-                
-            return cleaned_options
-        return v
 
 
 class MatchingListQuestion(BaseModel):
@@ -122,8 +86,8 @@ class MatchingListQuestion(BaseModel):
     often consists of multiple entries, this model represents just one complete entry.
     """
 
-    value1: str = Field(default="", description="The phrase to display on the left-hand side.")
-    value2: str = Field(default="", description="The phrase to display on the right-hand side.")
+    value1: list[Content] = Field(default_factory=list, description="The phrase to display on the left-hand side.")
+    value2: list[Content] = Field(default_factory=list, description="The phrase to display on the right-hand side.")
     difficulty: DifficultyType = "Average"
 
 

--- a/shiksha-api/app-service/app/routers/question_paper.py
+++ b/shiksha-api/app-service/app/routers/question_paper.py
@@ -52,7 +52,7 @@ def get_sample_text(data: Any) -> str:
     if isinstance(data, dict):
         for key, value in data.items():
             # Prioritize fields likely to contain full sentences or specific language content
-            if key in ['instructions', 'question_text', 'title', 'question', 'text', 'part_name']:
+            if key in ['instructions', 'question_text', 'title', 'question', 'text', 'part_name', 'content']:
                 if isinstance(value, str) and len(value.strip().split()) > 2:
                     return value
             res = get_sample_text(value)

--- a/shiksha-api/app-service/app/services/question_paper_service.py
+++ b/shiksha-api/app-service/app/services/question_paper_service.py
@@ -20,7 +20,6 @@ from llama_index.core.llms import ChatMessage
 from app.services.rag_adapters import BaseRagAdapter
 
 from app.models.question_paper import (
-    Content,
     FourOptionsQuestion,
     GeneratedQuestionItem,
     GeneratedTemplate,

--- a/shiksha-api/app-service/app/services/question_paper_service.py
+++ b/shiksha-api/app-service/app/services/question_paper_service.py
@@ -20,6 +20,7 @@ from llama_index.core.llms import ChatMessage
 from app.services.rag_adapters import BaseRagAdapter
 
 from app.models.question_paper import (
+    Content,
     FourOptionsQuestion,
     GeneratedQuestionItem,
     GeneratedTemplate,
@@ -30,6 +31,7 @@ from app.models.question_paper import (
     QuestionBankResponse,
     QuestionBankMetadata,
     QuestionDistribution,
+    QuestionModel,
     QuestionTypeResponse,
     GRAMMAR_QUESTION_TYPES,
     TextQuestion,
@@ -100,20 +102,20 @@ class QuestionPaperService:
         logger.info("Successfully loaded prompt templates")
         return prompts
 
-
-    def _flatten_existing_questions(self, existing: List[QuestionTypeResponse]) -> List[str]:
-        """Extract question text from existing questions for uniqueness checking."""
+    def _flatten_questions(self, existing: list[QuestionModel]) -> list[str]:
+        to_text = lambda v: "\n".join(c.content.decode("utf-8") for c in v if c.content_type == "text/plain")
         questions = []
-        for qtr in existing:
-            for q in qtr.questions:
-                match q:
-                    case TextQuestion(question=question) | FourOptionsQuestion(question=question):
-                        questions.append(question)
-                    case MatchingListQuestion(value1=value1, value2=value2):
-                        questions.append(f"{value1} :: {value2}")
-                    case _:
-                        raise RuntimeError("don't know how to flatten %s" % type(q).__qualname__)
-        return [q for q in questions if q]
+        for q in existing:
+            match q:
+                case TextQuestion(question=question) | FourOptionsQuestion(question=question):
+                    if text := to_text(question):
+                        questions.append(text)
+                case MatchingListQuestion(value1=value1, value2=value2):
+                    if (v1 := to_text(value1)) and (v2 := to_text(value2)):
+                        questions.append(f"{v1} :: {v2}")
+                case _:
+                    raise RuntimeError("don't know how to flatten %s" % type(q).__qualname__)
+        return questions
 
     def _get_grammar_topics(self, request: QuestionBankPartsGenerationRequest, record: _LearningRecord) -> str:
         """Return a grammar focus instruction for the slot, or "" when no grammar
@@ -304,7 +306,7 @@ class QuestionPaperService:
         Updated to provide default values for school_name and examination_name to prevent DB validation errors.
         """
 
-        existing_flat = self._flatten_existing_questions(request.existing_questions)
+        existing_flat = list({q for batch in request.existing_questions for q in self._flatten_questions(batch.questions)})
         tasks = []
         for lr, questions in self._build_generation_slots(request):
             logger.debug(f"[SLOT_PROCESSING] unit='{lr.title}' | index_path='{lr.index_path}'")

--- a/shiksha-api/app-service/tests/unit/services/test_question_paper_service.py
+++ b/shiksha-api/app-service/tests/unit/services/test_question_paper_service.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import MagicMock, patch
 from app.services.question_paper_service import QuestionPaperService
-from app.models.question_paper import Chapter, GeneratedTemplate, MatchingListQuestion, QuestionDistribution, QuestionType, TextQuestion
+from app.models.question_paper import Chapter, Content, GeneratedTemplate, MatchingListQuestion, QuestionDistribution, QuestionType, TextQuestion
 
 
 # Shared fixture to avoid recreating the service
@@ -28,32 +28,31 @@ class TestQuestionPaperServiceInitialization:
         assert hasattr(service, "prompts")
 
 
-class TestFlattenExistingQuestions:
-    """Tests for _flatten_existing_questions method."""
+class TestFlattenQuestions:
+    """Tests for _flatten_questions method."""
 
     def test_flatten_text_questions(self, service):
         """Test flattening text-based questions."""
-        mock_response = MagicMock()
-        mock_response.questions = [TextQuestion(question="What is photosynthesis?")]
-
-        result = service._flatten_existing_questions([mock_response])
+        questions = [TextQuestion(question=[Content.text("What is photosynthesis?")])]
+        result = service._flatten_questions(questions)
 
         assert len(result) == 1
         assert "What is photosynthesis?" in result
 
     def test_flatten_matching_questions(self, service):
         """Test flattening matching-type questions."""
-        mock_response = MagicMock()
-        mock_response.questions = [MatchingListQuestion(value1="Mitochondria", value2="Powerhouse of the cell")]
-
-        result = service._flatten_existing_questions([mock_response])
+        questions = [MatchingListQuestion(
+            value1=[Content.text("Mitochondria")],
+            value2=[Content.text("Powerhouse of the cell")],
+        )]
+        result = service._flatten_questions(questions)
 
         assert len(result) == 1
         assert "Mitochondria :: Powerhouse of the cell" in result
 
     def test_flatten_empty_list(self, service):
         """Test flattening empty list."""
-        result = service._flatten_existing_questions([])
+        result = service._flatten_questions([])
         assert result == []
 
 

--- a/shiksha-website/shiksha-backend/__tests__/unit/managers/question.bank.manager.test.js
+++ b/shiksha-website/shiksha-backend/__tests__/unit/managers/question.bank.manager.test.js
@@ -279,7 +279,7 @@ describe("QuestionBankManager", () => {
 
   describe("getQuestions", () => {
     it("should get questions successfully without translation", async () => {
-      mockQuestionBankDao.getQuestions = jest.fn().mockResolvedValue([{ text: "Q1", answerType: "MCQ", marksPerQuestion: 1, unit_name: "Unit 1", objective: "Knowledge", keyAnswer: "A" }]);
+      mockQuestionBankDao.getQuestions = jest.fn().mockResolvedValue([{ text: "Q1", answerType: "MCQ", marksPerQuestion: 1, unit_name: "Unit 1", objective: "Knowledge", keyAnswer: "A", options: [], pairs: [] }]);
       const masterSubjectDao = require("../../../dao/master.subject.dao");
       manager.masterSubjectDao = {
         resolveSubjectContext: jest.fn().mockResolvedValue({ subjectCode: "SC", targetSubjectIds: [] })
@@ -297,18 +297,18 @@ describe("QuestionBankManager", () => {
       expect(result.success).toBe(true);
       expect(result.data).toEqual([
         expect.objectContaining({
-          text: "Q1",
+          text: [{ contentType: "text/plain", content: "Q1" }],
           heading: "Multiple Choice Questions",
           unitName: "Unit 1",
           objective: "Knowledge",
-          keyAnswer: "A",
+          keyAnswer: [{ contentType: "text/plain", content: "A" }],
         }),
       ]);
     });
 
     it("should get questions and translate if targetLanguage is provided", async () => {
-      const rawQuestion = { text: "Q1", answerType: "MCQ", marksPerQuestion: 1, unit_name: "Unit 1", objective: "Knowledge", keyAnswer: "A" };
-      const translatedQuestion = { text: "Q1 Translated", answerType: "MCQ", marksPerQuestion: 1, unit_name: "Unit 1", objective: "Knowledge", keyAnswer: "A" };
+      const rawQuestion = { text: "Q1", answerType: "MCQ", marksPerQuestion: 1, unit_name: "Unit 1", objective: "Knowledge", keyAnswer: "A", options: [], pairs: [] };
+      const translatedQuestion = { text: "Q1 Translated", answerType: "MCQ", marksPerQuestion: 1, unit_name: "Unit 1", objective: "Knowledge", keyAnswer: "A", options: [], pairs: [] };
       mockQuestionBankDao.getQuestions = jest.fn().mockResolvedValue([rawQuestion]);
       const masterSubjectDao = require("../../../dao/master.subject.dao");
       manager.masterSubjectDao = {
@@ -330,11 +330,11 @@ describe("QuestionBankManager", () => {
       expect(result.success).toBe(true);
       expect(result.data).toEqual([
         expect.objectContaining({
-          text: "Q1 Translated",
+          text: [{ contentType: "text/plain", content: "Q1 Translated" }],
           heading: "Multiple Choice Questions",
           unitName: "Unit 1",
           objective: "Knowledge",
-          keyAnswer: "A",
+          keyAnswer: [{ contentType: "text/plain", content: "A" }],
         }),
       ]);
     });

--- a/shiksha-website/shiksha-backend/managers/question.bank.manager.js
+++ b/shiksha-website/shiksha-backend/managers/question.bank.manager.js
@@ -50,10 +50,11 @@ const getObjectiveKey = (board, grade, subjectName) => {
 const b64regex = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$/;
 const toQuestionContent = async value => {
   if(typeof value === "string") return [{ contentType: "text/plain", content: value }];
-  if(Array.isArray(value)) Promise.all(value.map(async item => {
-    if(item.contentType === "text/plain") return item;
-    if(b64regex.test(item.content)) return { contentType: item.contentType, content: Buffer.from(item.content, "base64").toString("utf8") }
-    return { ...(await getBlobContent(item.content, item.contentType)) }
+  if(Array.isArray(value)) return Promise.all(value.map(async item => {
+    if(item.contentType === "text/plain" || b64regex.test(item.content)) return item;
+    resp = await getBlobContent(item.content, item.contentType)
+    if(rep.contentType.startsWith("image/")) resp.content = Buffer.from(resp.content, "utf8").toString("base64")
+    return resp
   }));
   return value;
 };

--- a/shiksha-website/shiksha-backend/managers/question.bank.manager.js
+++ b/shiksha-website/shiksha-backend/managers/question.bank.manager.js
@@ -314,7 +314,7 @@ class QuestionBankManager extends BaseManager {
           if (!q.lbaQuestionId) return q;
           const rawQuestion = await mongoose.connection.collection("lba_questions").findOne({ _id: new ObjectId(q.lbaQuestionId) });
           const transformed = await transformWeakLbaQuestion(rawQuestion);
-          return { ...(Array.isArray(transformed) ? transformed[q.lbaPairIndex] : transformed), unitName: q.unitName, objective: q.objective, marks: q.marks };
+          return { ...(Array.isArray(transformed) && q.lbaPairIndex != null ? transformed[q.lbaPairIndex] : transformed), unitName: q.unitName, objective: q.objective, marks: q.marks };
         })),
       })));
       return { mergedList, notFoundQuestions, cacheSummary, rawCacheHit };

--- a/shiksha-website/shiksha-backend/managers/question.bank.manager.js
+++ b/shiksha-website/shiksha-backend/managers/question.bank.manager.js
@@ -26,6 +26,7 @@ const { addCacheJob } = require("./cache.queue.manager");
 const QuestionBankCacheSummary = require("../models/question.bank.cache.summary.model");
 const logger = require("../config/loggers");
 const PAPER_CONFIG = require("../config/question-bank-paper-config.json");
+const { getBlobContent } = require("../services/azure.blob.service");
 
 // really we should look at dropping the 'aliases' field here. ideally db.lba_questions should use lower-case key
 // as the 'answerType' (e.g., 'answer_short' instead of 'short_answer'/'short_answers'). right now, 'aliases' is
@@ -46,7 +47,17 @@ const getObjectiveKey = (board, grade, subjectName) => {
     ? policy.coreSubjectGrades[String(grade)] || policy.coreSubject
     : policy.default;
 };
-const transformWeakLbaQuestion = (q) => {
+const b64regex = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$/;
+const toQuestionContent = async value => {
+  if(typeof value === "string") return [{ contentType: "text/plain", content: value }];
+  if(Array.isArray(value)) Promise.all(value.map(async item => {
+    if(item.contentType === "text/plain") return item;
+    if(b64regex.test(item.content)) return { contentType: item.contentType, content: Buffer.from(item.content, "base64").toString("utf8") }
+    return { ...(await getBlobContent(item.content, item.contentType)) }
+  }));
+  return value;
+};
+const transformWeakLbaQuestion = async (q) => {
   // this exists because db.lba_questions has weak and inconsistent structure.
   // TODO: we ought to get rid of this backend logic by sanitizing the db collection.
   const meta = QUESTION_TYPE_META[q.answerType];
@@ -60,20 +71,16 @@ const transformWeakLbaQuestion = (q) => {
     marks: q.marksPerQuestion,
     unitName: unit_name,
     objective: q.objective,
-    text: q.text,
-    keyAnswer: q.keyAnswer,
-    value1: q.value1,
-    value2: q.value2,
+    text: await toQuestionContent(q.text),
+    keyAnswer: await toQuestionContent(q.keyAnswer ?? q.keyanswer),
+    options: q.options ? await Promise.all(q.options.map(async option => ({ ...option, text: await toQuestionContent(option.text) }))) : q.options,
   };
-  return q.pairs?.length ? q.pairs.map((pair, index) => ({
-    ...base,
-    _id: `${q._id}_pair_${index}`,
-    text: pair.left,
-    value1: pair.left,
-    value2: pair.right,
+  delete q.keyanswer;
+  return q.pairs?.length ? Promise.all(q.pairs.map(async (pair, index) => {
+    const value1 = await toQuestionContent(pair.left);
+    return { ...base, _id: `${q._id}_pair_${index}`, text: value1, value1, value2: await toQuestionContent(pair.right) };
   })) : base;
 };
-
 class QuestionBankManager extends BaseManager {
   constructor() {
     super(new QuestionBankDao());
@@ -300,7 +307,15 @@ class QuestionBankManager extends BaseManager {
 
     if (questions && questions.length > 0) {
       console.log("[Manager] Manual Flow detected. Using provided questions/sections.");
-      mergedList = questions;
+      mergedList = await Promise.all(questions.map(async section => ({
+        ...section,
+        questions: await Promise.all(section.questions.map(async q => {
+          if (!q.lbaQuestionId) return q;
+          const rawQuestion = await mongoose.connection.collection("lba_questions").findOne({ _id: new ObjectId(q.lbaQuestionId) });
+          const transformed = await transformWeakLbaQuestion(rawQuestion);
+          return { ...(Array.isArray(transformed) ? transformed[q.lbaPairIndex] : transformed), unitName: q.unitName, objective: q.objective, marks: q.marks };
+        })),
+      })));
       return { mergedList, notFoundQuestions, cacheSummary, rawCacheHit };
     }
 
@@ -970,10 +985,10 @@ class QuestionBankManager extends BaseManager {
           // fall back to the untranslated result which is already in `result`
         }
       }
-      result = result.flatMap(transformWeakLbaQuestion);
+      result = (await Promise.all(result.map(transformWeakLbaQuestion))).flat();
 
       console.log(`[Manager] getQuestions: found ${result?.length || 0} questions`);
-      return formatApiReponse(true, "Questions retrieved successfully", result);
+      return formatApiReponse(true, "Questions retrieved successfully", convertToCamelCase(result));
     } catch (err) {
       console.error("[Manager] getQuestions error:", err);
       return formatApiReponse(false, err.message, err);

--- a/shiksha-website/shiksha-backend/managers/question.bank.manager.js
+++ b/shiksha-website/shiksha-backend/managers/question.bank.manager.js
@@ -308,12 +308,14 @@ class QuestionBankManager extends BaseManager {
 
     if (questions && questions.length > 0) {
       console.log("[Manager] Manual Flow detected. Using provided questions/sections.");
+      const ids = [...new Set(questions.flatMap(section => section.questions.map(q => q.lbaQuestionId).filter(Boolean)))];
+      const rawQuestions = ids.length ? await mongoose.connection.collection("lba_questions").find({ _id: { $in: ids.map(id => new ObjectId(id)) } }).toArray() : [];
+      const rawQuestionById = new Map(rawQuestions.map(q => [String(q._id), q]));
       mergedList = await Promise.all(questions.map(async section => ({
         ...section,
         questions: await Promise.all(section.questions.map(async q => {
           if (!q.lbaQuestionId) return q;
-          const rawQuestion = await mongoose.connection.collection("lba_questions").findOne({ _id: new ObjectId(q.lbaQuestionId) });
-          const transformed = await transformWeakLbaQuestion(rawQuestion);
+          const transformed = await transformWeakLbaQuestion(rawQuestionById.get(String(q.lbaQuestionId)));
           return { ...(Array.isArray(transformed) && q.lbaPairIndex != null ? transformed[q.lbaPairIndex] : transformed), unitName: q.unitName, objective: q.objective, marks: q.marks };
         })),
       })));

--- a/shiksha-website/shiksha-backend/managers/question.bank.manager.js
+++ b/shiksha-website/shiksha-backend/managers/question.bank.manager.js
@@ -52,9 +52,7 @@ const toQuestionContent = async value => {
   if(typeof value === "string") return [{ contentType: "text/plain", content: value }];
   if(Array.isArray(value)) return Promise.all(value.map(async item => {
     if(item.contentType === "text/plain" || b64regex.test(item.content)) return item;
-    resp = await getBlobContent(item.content, item.contentType)
-    if(resp.contentType.startsWith("image/")) resp.content = Buffer.from(resp.content, "utf8").toString("base64")
-    return resp
+    return await getBlobContent(item.content, item.contentType)
   }));
   return value;
 };

--- a/shiksha-website/shiksha-backend/managers/question.bank.manager.js
+++ b/shiksha-website/shiksha-backend/managers/question.bank.manager.js
@@ -53,7 +53,7 @@ const toQuestionContent = async value => {
   if(Array.isArray(value)) return Promise.all(value.map(async item => {
     if(item.contentType === "text/plain" || b64regex.test(item.content)) return item;
     resp = await getBlobContent(item.content, item.contentType)
-    if(rep.contentType.startsWith("image/")) resp.content = Buffer.from(resp.content, "utf8").toString("base64")
+    if(resp.contentType.startsWith("image/")) resp.content = Buffer.from(resp.content, "utf8").toString("base64")
     return resp
   }));
   return value;

--- a/shiksha-website/shiksha-backend/services/azure.blob.service.js
+++ b/shiksha-website/shiksha-backend/services/azure.blob.service.js
@@ -96,6 +96,22 @@ async function getPreSignedUrl(blobName, expiryInSeconds) {
     return blobUrl;
 }
 
+function getBlobName(blobRef) {
+    try {
+        const pathname = decodeURIComponent(new URL(blobRef).pathname).replace(/^\/+/, "");
+        return pathname.startsWith(`${containerName}/`) ? pathname.slice(containerName.length + 1) : pathname;
+    } catch {
+        return blobRef;
+    }
+}
+
+async function getBlobContent(blobRef, contentType) {
+    const containerClient = blobServiceClient.getContainerClient(containerName);
+    const blobClient = containerClient.getBlockBlobClient(getBlobName(blobRef));
+    const [buffer, properties] = await Promise.all([blobClient.downloadToBuffer(), blobClient.getProperties()]);
+    return {contentType: contentType || properties.contentType, content: buffer.toString("base64")};
+}
+
 async function getPreSignedProfileImageUrl(userId) {
     const linkExpiryInSeconds = 7 * 24 * 60 * 60;
     const destinationObject = `${userId}_photo`;
@@ -114,4 +130,4 @@ async function getPreSignedFileUrl(filePath) {
     return fileUrl;
 }
 
-module.exports = { uploadToStorage, getPreSignedProfileImageUrl, getPreSignedFileUrl };
+module.exports = { uploadToStorage, getPreSignedProfileImageUrl, getPreSignedFileUrl, getBlobContent };

--- a/shiksha-website/shiksha-frontend/package-lock.json
+++ b/shiksha-website/shiksha-frontend/package-lock.json
@@ -34,6 +34,7 @@
         "exceljs": "^4.4.0",
         "file-saver": "^2.0.5",
         "html2canvas": "^1.4.1",
+        "image-size": "^2.0.2",
         "katex": "^0.16.25",
         "marked": "^4.3.0",
         "ng-otp-input": "^1.9.3",
@@ -9529,12 +9530,9 @@
       }
     },
     "node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
       "bin": {
         "image-size": "bin/image-size.js"
       },
@@ -12925,6 +12923,20 @@
         "https": "^1.0.0",
         "image-size": "^1.0.0",
         "jszip": "^3.7.1"
+      }
+    },
+    "node_modules/pptxgenjs/node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
       }
     },
     "node_modules/pretty-bytes": {
@@ -23387,12 +23399,9 @@
       }
     },
     "image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "requires": {
-        "queue": "6.0.2"
-      }
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w=="
     },
     "immediate": {
       "version": "3.0.6",
@@ -25859,6 +25868,16 @@
         "https": "^1.0.0",
         "image-size": "^1.0.0",
         "jszip": "^3.7.1"
+      },
+      "dependencies": {
+        "image-size": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+          "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+          "requires": {
+            "queue": "6.0.2"
+          }
+        }
       }
     },
     "pretty-bytes": {

--- a/shiksha-website/shiksha-frontend/package.json
+++ b/shiksha-website/shiksha-frontend/package.json
@@ -40,6 +40,7 @@
     "exceljs": "^4.4.0",
     "file-saver": "^2.0.5",
     "html2canvas": "^1.4.1",
+    "image-size": "^2.0.2",
     "katex": "^0.16.25",
     "marked": "^4.3.0",
     "ng-otp-input": "^1.9.3",

--- a/shiksha-website/shiksha-frontend/src/app/shared/models/question-bank.dto.ts
+++ b/shiksha-website/shiksha-frontend/src/app/shared/models/question-bank.dto.ts
@@ -5,7 +5,7 @@ export interface OptionDto {
 
 export interface QuestionDto {
   question: string;
-  options?: (string | OptionDto)[];
+  options?: OptionDto[];
   value1?: string;
   value2?: string;
   text?: string;

--- a/shiksha-website/shiksha-frontend/src/app/shared/services/blue-print.export.service.ts
+++ b/shiksha-website/shiksha-frontend/src/app/shared/services/blue-print.export.service.ts
@@ -104,8 +104,8 @@ export class BluePrintExportService {
         new TableRow({
           children: [
             this.createPaddedCell(item.unitName),
-            this.createPaddedCell(this.translateService.instant(item.type)),
-            this.createPaddedCell(this.translateService.instant(item.objective)),
+            this.createPaddedCell(this.translate(item.type)),
+            this.createPaddedCell(this.translate(item.objective)),
             this.createPaddedCell(formatMarks(item.marks)),
           ],
         })
@@ -160,6 +160,11 @@ export class BluePrintExportService {
       margins: { top: 100, bottom: 100, left: 100, right: 100 },
       width: { size: 25, type: WidthType.PERCENTAGE },
     });
+  }
+
+  private translate(value: unknown): string {
+    if (value == null || value === '') return '';
+    return this.translateService.instant(String(value));
   }
 
   private capitalize(str: string) {

--- a/shiksha-website/shiksha-frontend/src/app/shared/services/question-bank-download.service.ts
+++ b/shiksha-website/shiksha-frontend/src/app/shared/services/question-bank-download.service.ts
@@ -14,6 +14,7 @@ import {
   WidthType,
   PageNumber,
   TabStopType,
+  ImageRun,
 } from 'docx';
 import { saveAs } from 'file-saver';
 import { UtilityService } from 'src/app/core/services/utility.service';
@@ -21,17 +22,14 @@ import { DOCX_CONFIG, formatMarks, SUPERSCRIPT_MAP } from '../utility/constant.u
 import { OptionDto, QuestionSectionDto } from '../models/question-bank.dto';
 import { TranslateService } from '@ngx-translate/core';
 
-/** Interfaces for Question Bank Data */
 export interface QuestionBankMetadata {
   schoolName: string;
 }
 
-export type QuestionBankOption = string | OptionDto;
-
 export interface QuestionBankQuestion {
   question?: string;
   text?: string;
-  options?: QuestionBankOption[];
+  options?: OptionDto[];
   value1?: string;
   value2?: string;
   left?: string;
@@ -146,19 +144,8 @@ export class QuestionBankDownloadService {
       );
     }
 
-    const col1 = questions.map((q) => (q.value1 ?? q.left ?? q.text ?? '') || '');
-    const rawCol2 = questions.map((q, idx) => {
-      const resolved = q.value2 ?? q.right ?? q.keyAnswer;
-      if (typeof resolved !== 'string' || resolved.trim() === '') {
-        console.warn(
-          `[QuestionBankDownloadService.buildMatchTable] Row ${idx}: no valid right-hand match value found ` +
-            `(value2/right/keyAnswer). Falling back to empty string.`,
-          q
-        );
-        return '';
-      }
-      return resolved;
-    });
+    const col1 = questions.map((q) => q.value1 ?? q.left ?? q.text);
+    const rawCol2 = questions.map((q) => q.value2 ?? q.right ?? q.keyAnswer);
     const col2 = shuffle ? this.utilityService.shuffleOptions([...rawCol2]) : rawCol2;
 
     for (let i = 0; i < col1.length; i++) {
@@ -169,7 +156,7 @@ export class QuestionBankDownloadService {
               width: { size: 50, type: WidthType.PERCENTAGE },
               children: [
                 new Paragraph({
-                  children: this.convertToDocxRuns(col1[i]),
+                  children: this.contentRuns(col1[i]),
                   spacing: DOCX_CONFIG.spacing.tableCell,
                 }),
               ],
@@ -178,7 +165,7 @@ export class QuestionBankDownloadService {
               width: { size: 50, type: WidthType.PERCENTAGE },
               children: [
                 new Paragraph({
-                  children: this.convertToDocxRuns(col2[i]),
+                  children: this.contentRuns(col2[i]),
                   spacing: DOCX_CONFIG.spacing.tableCell,
                 }),
               ],
@@ -199,10 +186,9 @@ export class QuestionBankDownloadService {
     const paragraphs: Paragraph[] = [];
 
     questions.forEach((q, index) => {
-      const questionText = q.question ?? q.text ?? '';
       paragraphs.push(
         new Paragraph({
-          children: [new TextRun({ text: `${index + 1}. ` }), ...this.convertToDocxRuns(questionText)],
+          children: [new TextRun({ text: `${index + 1}. ` }), ...this.contentRuns(q.question ?? q.text)],
           spacing: DOCX_CONFIG.spacing.questionItem,
         })
       );
@@ -210,13 +196,12 @@ export class QuestionBankDownloadService {
       // Options render in both the standard bank and answer-key layouts so that
       // objective questions retain context alongside their answers.
       if (q.options) {
-        q.options.forEach((opt: QuestionBankOption, i: number) => {
-          const { label, text } = this.decodeOption(opt, i);
+        q.options.forEach((opt: OptionDto, i: number) => {
           paragraphs.push(
             new Paragraph({
               children: [
-                new TextRun({ text: `${DOCX_CONFIG.indent.optionLeft}${label}. ` }),
-                ...this.convertToDocxRuns(text),
+                new TextRun({ text: `${DOCX_CONFIG.indent.optionLeft}${opt.label || String.fromCharCode(65 + i)}. ` }),
+                ...this.contentRuns(opt.text),
               ],
               spacing: DOCX_CONFIG.spacing.optionItem,
             })
@@ -225,22 +210,12 @@ export class QuestionBankDownloadService {
       }
 
       if (showAnswers) {
-        let answer = '';
-        if (typeof q.keyAnswer === 'string') {
-          answer = q.keyAnswer;
-        } else if (q.keyAnswer !== undefined && q.keyAnswer !== null) {
-          console.error(
-            `[QuestionBankDownloadService.buildStandardQuestions] Question ${index + 1}: keyAnswer is not a string ` +
-              `(got ${typeof q.keyAnswer}). Falling back to empty string to prevent docx failure.`,
-            q
-          );
-        }
-        if (answer) {
+        if (q.keyAnswer) {
           paragraphs.push(
             new Paragraph({
               children: [
                 new TextRun({ text: '   Ans: ', bold: true, color: COLOR_ANSWER }),
-                new TextRun({ text: answer, italics: true, color: COLOR_ANSWER }),
+                ...this.contentRuns(q.keyAnswer),
               ],
               spacing: DOCX_CONFIG.spacing.optionItem,
             })
@@ -252,31 +227,13 @@ export class QuestionBankDownloadService {
     return paragraphs;
   }
 
-  /**
-   * Decodes a single MCQ option into { label, text }, mirroring the preview pattern used in
-   * `question-bank-blue-print.component.html` so downloads never render `[object Object]`.
-   * Supports three shapes:
-   *   - { label, text } → label from data, text from data
-   *   - { text }        → label auto-assigned (A, B, C…), text from data
-   *   - primitive       → label auto-assigned, text is the primitive coerced to string
-   */
-  private decodeOption(opt: QuestionBankOption | null | undefined, index: number): { label: string; text: string } {
-    const autoLabel = String.fromCharCode(65 + index);
-
-    if (opt && typeof opt === 'object') {
-      const label = typeof opt.label === 'string' && opt.label.trim() !== '' ? opt.label : autoLabel;
-      if (typeof opt.text === 'string') {
-        return { label, text: opt.text };
-      }
-      console.warn(
-        `[QuestionBankDownloadService.decodeOption] Option ${index} is an object without a string 'text' field. ` +
-          `Falling back to empty string.`,
-        opt
-      );
-      return { label, text: '' };
-    }
-
-    return { label: autoLabel, text: opt == null ? '' : String(opt) };
+  private contentRuns(content: any): any[] {
+    if (!Array.isArray(content)) return this.convertToDocxRuns(content);
+    return content.flatMap(item => {
+      if (item.contentType === 'text/plain') return this.convertToDocxRuns(item.content);
+      const type: 'jpg' | 'png' = item.contentType === 'image/jpeg' ? 'jpg' : 'png';
+      return [new ImageRun({ type, data: Uint8Array.from(atob(item.content), c => c.charCodeAt(0)), transformation: { width: 240, height: 160 } })];
+    });
   }
 
   /** Shared Document Shell */

--- a/shiksha-website/shiksha-frontend/src/app/shared/services/question-bank-download.service.ts
+++ b/shiksha-website/shiksha-frontend/src/app/shared/services/question-bank-download.service.ts
@@ -114,66 +114,24 @@ export class QuestionBankDownloadService {
 
   /** Builds a table for Match the Following questions */
   private buildMatchTable(questions: QuestionBankQuestion[], shuffle: boolean): Table {
-    const rows: TableRow[] = [];
+    const row = (left: any, right: any, bold = false) => new TableRow({
+      children: [left, right].map(content => new TableCell({
+        width: { size: 50, type: WidthType.PERCENTAGE },
+        children: [new Paragraph({
+          children: bold
+            ? [new TextRun({ text: content, bold: true })]
+            : this.contentRuns(content),
+          spacing: DOCX_CONFIG.spacing.tableCell,
+        })],
+      })),
+    });
 
-    // Header Row (Only for Answer Key as per original logic, let's keep it consistent)
-    if (!shuffle) {
-      rows.push(
-        new TableRow({
-          children: [
-            new TableCell({
-              width: { size: 50, type: WidthType.PERCENTAGE },
-              children: [
-                new Paragraph({
-                  children: [new TextRun({ text: ' Left', bold: true })],
-                  spacing: DOCX_CONFIG.spacing.tableCell,
-                }),
-              ],
-            }),
-            new TableCell({
-              width: { size: 50, type: WidthType.PERCENTAGE },
-              children: [
-                new Paragraph({
-                  children: [new TextRun({ text: ' Right (Answer)', bold: true })],
-                  spacing: DOCX_CONFIG.spacing.tableCell,
-                }),
-              ],
-            }),
-          ],
-        })
-      );
-    }
+    const left = questions.map(q => q.value1 ?? q.left ?? q.text);
+    const answers = questions.map(q => q.value2 ?? q.right ?? q.keyAnswer);
+    const right = shuffle ? this.utilityService.shuffleOptions([...answers]) : answers;
+    const rows = left.map((value, index) => row(value, right[index]));
 
-    const col1 = questions.map((q) => q.value1 ?? q.left ?? q.text);
-    const rawCol2 = questions.map((q) => q.value2 ?? q.right ?? q.keyAnswer);
-    const col2 = shuffle ? this.utilityService.shuffleOptions([...rawCol2]) : rawCol2;
-
-    for (let i = 0; i < col1.length; i++) {
-      rows.push(
-        new TableRow({
-          children: [
-            new TableCell({
-              width: { size: 50, type: WidthType.PERCENTAGE },
-              children: [
-                new Paragraph({
-                  children: this.contentRuns(col1[i]),
-                  spacing: DOCX_CONFIG.spacing.tableCell,
-                }),
-              ],
-            }),
-            new TableCell({
-              width: { size: 50, type: WidthType.PERCENTAGE },
-              children: [
-                new Paragraph({
-                  children: this.contentRuns(col2[i]),
-                  spacing: DOCX_CONFIG.spacing.tableCell,
-                }),
-              ],
-            }),
-          ],
-        })
-      );
-    }
+    if (!shuffle) rows.unshift(row('Left', 'Right (Answer)', true));
 
     return new Table({
       width: { size: 100, type: WidthType.PERCENTAGE },

--- a/shiksha-website/shiksha-frontend/src/app/shared/services/question-bank-download.service.ts
+++ b/shiksha-website/shiksha-frontend/src/app/shared/services/question-bank-download.service.ts
@@ -17,6 +17,7 @@ import {
   ImageRun,
 } from 'docx';
 import { saveAs } from 'file-saver';
+import { imageSize } from 'image-size';
 import { UtilityService } from 'src/app/core/services/utility.service';
 import { DOCX_CONFIG, formatMarks, SUPERSCRIPT_MAP } from '../utility/constant.util';
 import { OptionDto, QuestionSectionDto } from '../models/question-bank.dto';
@@ -190,7 +191,9 @@ export class QuestionBankDownloadService {
     return content.flatMap(item => {
       if (item.contentType === 'text/plain') return this.convertToDocxRuns(item.content);
       const type: 'jpg' | 'png' = item.contentType === 'image/jpeg' ? 'jpg' : 'png';
-      return [new ImageRun({ type, data: Uint8Array.from(atob(item.content), c => c.charCodeAt(0)), transformation: { width: 240, height: 160 } })];
+      const data = Uint8Array.from(atob(item.content), c => c.charCodeAt(0));
+      const { width = 240, height = 160 } = imageSize(data);
+      return [new ImageRun({ type, data, transformation: { width: 240, height: 240 * height / width } })];
     });
   }
 

--- a/shiksha-website/shiksha-frontend/src/app/shared/utility/question-bank-display.util.ts
+++ b/shiksha-website/shiksha-frontend/src/app/shared/utility/question-bank-display.util.ts
@@ -1,0 +1,21 @@
+export interface QuestionContentItem {
+  contentType: string;
+  content: string;
+}
+
+export function contentItems(content: unknown): QuestionContentItem[] {
+  if (content == null) return [];
+  if (Array.isArray(content)) return content as QuestionContentItem[];
+  return [{ contentType: 'text/plain', content: String(content) }];
+}
+
+export function questionContentItems(question: any): QuestionContentItem[] {
+  if (question?.type === 'MATCHING') {
+    return [...contentItems(question.value1), { contentType: 'text/plain', content: '-' }, ...contentItems(question.value2)];
+  }
+  return contentItems(question?.text ?? question?.question);
+}
+
+export function questionText(question: any): string {
+  return questionContentItems(question).filter(item => item.contentType === 'text/plain').map(item => item.content) .join(' ');
+}

--- a/shiksha-website/shiksha-frontend/src/app/shared/utility/question-bank-display.util.ts
+++ b/shiksha-website/shiksha-frontend/src/app/shared/utility/question-bank-display.util.ts
@@ -19,3 +19,12 @@ export function questionContentItems(question: any): QuestionContentItem[] {
 export function questionText(question: any): string {
   return questionContentItems(question).filter(item => item.contentType === 'text/plain').map(item => item.content) .join(' ');
 }
+
+export function hasQuestionImage(question: any): boolean {
+  const content = [
+    ...questionContentItems(question),
+    ...contentItems(question?.keyAnswer),
+    ...(question?.options || []).flatMap((option: any) => contentItems(option?.text)),
+  ];
+  return content.some(item => item.contentType?.startsWith('image/'));
+}

--- a/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-blue-print/question-bank-blue-print.component.html
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-blue-print/question-bank-blue-print.component.html
@@ -31,27 +31,12 @@
             <div *ngFor="let q of group.questions; let j = index" class="bg-white p-3 rounded border flex gap-3">
               <span class="text-gray-400 font-bold text-sm">{{ j + 1 }}.</span>
               <div class="flex-1">
-                  <div *ngIf="q.type !== 'MATCHING'">
-                    <p class="text-sm text-content mb-2">
-                      <ng-container *ngFor="let item of contentItems(q.text)">
-                        <span *ngIf="item.contentType === 'text/plain'">{{ item.content }}</span>
-                        <img *ngIf="item.contentType !== 'text/plain'" [src]="mediaSrc(item)" class="mt-2 max-h-40 max-w-full" />
-                      </ng-container>
-                    </p>
-                  </div>
-                  <div *ngIf="q.type === 'MATCHING'">
-                    <p class="text-sm text-content mb-2">
-                      <ng-container *ngFor="let item of contentItems(q.value1)">
-                        <span *ngIf="item.contentType === 'text/plain'">{{ item.content }}</span>
-                        <img *ngIf="item.contentType !== 'text/plain'" [src]="mediaSrc(item)" class="mt-2 max-h-40 max-w-full" />
-                      </ng-container>
-                      <span> - </span>
-                      <ng-container *ngFor="let item of contentItems(q.value2)">
-                        <span *ngIf="item.contentType === 'text/plain'">{{ item.content }}</span>
-                        <img *ngIf="item.contentType !== 'text/plain'" [src]="mediaSrc(item)" class="mt-2 max-h-40 max-w-full" />
-                      </ng-container>
-                    </p>
-                  </div>
+                <p class="text-sm text-content mb-2">
+                  <ng-container *ngFor="let item of questionContentItems(q)">
+                    <span *ngIf="item.contentType === 'text/plain'">{{ item.content }}</span>
+                    <img *ngIf="item.contentType !== 'text/plain'" [src]="mediaSrc(item)" class="mt-2 max-h-40 max-w-full" />
+                  </ng-container>
+                </p>
                 <div *ngIf="q.options && q.options.length > 0" class="ml-4 mb-2">
                   <div *ngFor="let option of q.options" class="text-xs text-gray-600">
                     <b *ngIf="option.label">{{ option.label }}.</b>

--- a/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-blue-print/question-bank-blue-print.component.html
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-blue-print/question-bank-blue-print.component.html
@@ -44,7 +44,6 @@
                       <span *ngIf="item.contentType === 'text/plain'"> {{ item.content }}</span>
                       <img *ngIf="item.contentType !== 'text/plain'" [src]="mediaSrc(item)" class="mt-1 max-h-24 max-w-full" />
                     </ng-container>
-                    <span *ngIf="!option.label && !option.text">{{ option }}</span>
                   </div>
                 </div>
                 <!-- Removed Topic, Obj, Source per user request -->

--- a/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-blue-print/question-bank-blue-print.component.html
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-blue-print/question-bank-blue-print.component.html
@@ -31,11 +31,34 @@
             <div *ngFor="let q of group.questions; let j = index" class="bg-white p-3 rounded border flex gap-3">
               <span class="text-gray-400 font-bold text-sm">{{ j + 1 }}.</span>
               <div class="flex-1">
-                <p class="text-sm text-content mb-2" [innerHTML]="q.text"></p>
+                  <div *ngIf="q.type !== 'MATCHING'">
+                    <p class="text-sm text-content mb-2">
+                      <ng-container *ngFor="let item of contentItems(q.text)">
+                        <span *ngIf="item.contentType === 'text/plain'">{{ item.content }}</span>
+                        <img *ngIf="item.contentType !== 'text/plain'" [src]="mediaSrc(item)" class="mt-2 max-h-40 max-w-full" />
+                      </ng-container>
+                    </p>
+                  </div>
+                  <div *ngIf="q.type === 'MATCHING'">
+                    <p class="text-sm text-content mb-2">
+                      <ng-container *ngFor="let item of contentItems(q.value1)">
+                        <span *ngIf="item.contentType === 'text/plain'">{{ item.content }}</span>
+                        <img *ngIf="item.contentType !== 'text/plain'" [src]="mediaSrc(item)" class="mt-2 max-h-40 max-w-full" />
+                      </ng-container>
+                      <span> - </span>
+                      <ng-container *ngFor="let item of contentItems(q.value2)">
+                        <span *ngIf="item.contentType === 'text/plain'">{{ item.content }}</span>
+                        <img *ngIf="item.contentType !== 'text/plain'" [src]="mediaSrc(item)" class="mt-2 max-h-40 max-w-full" />
+                      </ng-container>
+                    </p>
+                  </div>
                 <div *ngIf="q.options && q.options.length > 0" class="ml-4 mb-2">
                   <div *ngFor="let option of q.options" class="text-xs text-gray-600">
-                    <span *ngIf="option.label"><b>{{ option.label }}.</b> {{ option.text }}</span>
-                    <span *ngIf="!option.label && option.text">{{ option.text }}</span>
+                    <b *ngIf="option.label">{{ option.label }}.</b>
+                    <ng-container *ngFor="let item of contentItems(option.text)">
+                      <span *ngIf="item.contentType === 'text/plain'"> {{ item.content }}</span>
+                      <img *ngIf="item.contentType !== 'text/plain'" [src]="mediaSrc(item)" class="mt-1 max-h-24 max-w-full" />
+                    </ng-container>
                     <span *ngIf="!option.label && !option.text">{{ option }}</span>
                   </div>
                 </div>

--- a/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-blue-print/question-bank-blue-print.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-blue-print/question-bank-blue-print.component.ts
@@ -116,6 +116,14 @@ export class QuestionBankBluePrintComponent implements OnInit, OnChanges {
     return Array.from(sources);
   }
 
+  mediaSrc(item: any): string {
+    return `data:${item.contentType};base64,${item.content}`;
+  }
+
+  contentItems(content: any): any[] {
+    return Array.isArray(content) ? content : [{ contentType: 'text/plain', content }];
+  }
+
   previousStep() {
     this.backClick.emit();
   }

--- a/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-blue-print/question-bank-blue-print.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-blue-print/question-bank-blue-print.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
 import { ChartConfiguration, ChartData } from 'chart.js';
 import { formatMarks, QUESTION_SOURCE } from 'src/app/shared/utility/constant.util';
+import { contentItems, questionContentItems } from 'src/app/shared/utility/question-bank-display.util';
 
 @Component({
   selector: 'app-question-bank-blue-print',
@@ -22,6 +23,8 @@ export class QuestionBankBluePrintComponent implements OnInit, OnChanges {
   @Output() backClick = new EventEmitter<void>();
   @Output() generateClick = new EventEmitter<void>();
   readonly formatMarks = formatMarks;
+  readonly contentItems = contentItems;
+  readonly questionContentItems = questionContentItems;
 
   totalSteps: number = 3;
 
@@ -118,10 +121,6 @@ export class QuestionBankBluePrintComponent implements OnInit, OnChanges {
 
   mediaSrc(item: any): string {
     return `data:${item.contentType};base64,${item.content}`;
-  }
-
-  contentItems(content: any): any[] {
-    return Array.isArray(content) ? content : [{ contentType: 'text/plain', content }];
   }
 
   previousStep() {

--- a/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-generation.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-generation.component.ts
@@ -176,7 +176,7 @@ export class QuestionBankGenerationComponent implements OnInit, OnDestroy {
         grouped.set(sectionKey, { type: sectionType, numberOfQuestions: 0, marksPerQuestion: Number(q.marks), questions: [] });
       }
       const sec = grouped.get(sectionKey);
-      sec.questions.push({ question: q.text, options: q.options, answer: q.answer, marks: Number(q.marks), value1: q.value1, value2: q.value2 });
+      sec.questions.push(this.slimLbaQuestion(q));
       sec.numberOfQuestions = sec.questions.length;
     });
 
@@ -674,7 +674,7 @@ export class QuestionBankGenerationComponent implements OnInit, OnDestroy {
         });
       }
       const section = sectionsMap.get(sectionKey);
-      section.questions.push({
+      section.questions.push(q.source === QUESTION_SOURCE.AI ? {
         question: q.text,
         options: q.options,
         keyAnswer: q.keyAnswer,
@@ -684,7 +684,7 @@ export class QuestionBankGenerationComponent implements OnInit, OnDestroy {
         objective: q.objective,
         value1: q.value1,
         value2: q.value2
-      });
+      } : this.slimLbaQuestion(q));
       section.numberOfQuestions = section.questions.length;
     });
 
@@ -721,6 +721,18 @@ export class QuestionBankGenerationComponent implements OnInit, OnDestroy {
 
   private extractIdFromResponse(res: any): string | undefined {
     return res.data._id;
+  }
+
+  slimLbaQuestion(q: any): any {
+    const [lbaQuestionId, lbaPairIndex] = String(q._id).split('_pair_');
+    return {
+      _id: q._id,
+      lbaQuestionId,
+      lbaPairIndex: Number(lbaPairIndex),
+      marks: Number(q.marks),
+      unitName: q.unitName,
+      objective: q.objective,
+    };
   }
 
   generateAIQuestionsPool() {
@@ -920,9 +932,19 @@ export class QuestionBankGenerationComponent implements OnInit, OnDestroy {
   applyFilters() {
     this.filteredQuestions = this.allAvailableQuestions.filter(q => {
       const matchesSource = this.filterSource === 'ALL' || q.source === this.filterSource;
-      const matchesSearch = q.text.toLowerCase().includes(this.searchQuery);
+      const matchesSearch = this.questionText(q).toLowerCase().includes(this.searchQuery);
       return matchesSource && matchesSearch;
     });
+  }
+
+  questionText(question: any): string {
+    const components = [];
+    if(question.type === 'MATCHING'){
+      components.push(...question.value1, {contentType: 'text/plain', content: '-'}, ...question.value2);
+    }else{
+      components.push(question.text);
+    }
+    return components.filter((item: any) => item.contentType === 'text/plain').map((item: any) => item.content).join(' ');
   }
 
   get isTotalMet(): boolean { return this.currentTotalMarks === this.totalMarks; }

--- a/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-generation.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-generation.component.ts
@@ -726,11 +726,13 @@ export class QuestionBankGenerationComponent implements OnInit, OnDestroy {
   }
 
   slimLbaQuestion(q: any): any {
-    const [lbaQuestionId, lbaPairIndex] = String(q._id).split('_pair_');
+    const parts = String(q._id).split('_pair_');
+    const lbaQuestionId = parts[0];
+    const lbaPairIndex = parts.length > 1 ? Number(parts[1]) : undefined;
     return {
       _id: q._id,
       lbaQuestionId,
-      lbaPairIndex: Number(lbaPairIndex),
+      lbaPairIndex,
       marks: Number(q.marks),
       unitName: q.unitName,
       objective: q.objective,

--- a/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-generation.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-generation.component.ts
@@ -18,6 +18,7 @@ import { fadeInOutAnimation } from 'src/app/shared/utility/animations.util';
 import { HttpClient } from '@angular/common/http';
 import { forkJoin, of } from 'rxjs';
 import { map, switchMap, catchError, finalize, toArray } from 'rxjs/operators';
+import { questionContentItems, questionText } from 'src/app/shared/utility/question-bank-display.util';
 
 // Import Child Component for Step 2 access
 import { QuestionBankTemplateComponent } from './question-bank-template/question-bank-template.component';
@@ -38,6 +39,7 @@ export class QuestionBankGenerationComponent implements OnInit, OnDestroy {
   @ViewChild(QuestionBankTemplateComponent) templateComponent!: QuestionBankTemplateComponent;
   @ViewChild('headingDropdownContainer') headingDropdownContainer?: ElementRef<HTMLElement>;
   readonly formatMarks = formatMarks;
+  readonly questionText = questionText;
 
   questionBankConfigForm!: FormGroup;
   submittedConfig: boolean = false;
@@ -522,7 +524,7 @@ export class QuestionBankGenerationComponent implements OnInit, OnDestroy {
         .forEach(q => {
           q.marksPerQuestion.forEach((marks: number) => {
             const selectionKey = q.key;
-            if (!headingMap.has(selectionKey)) headingMap.set(selectionKey, { ...q, selectionKey, displayName: q.label, name: q.label, label: q.label, count: 0, chapters: new Set<number>(), aiVariants: [], lbaName: undefined });
+            if (!headingMap.has(selectionKey)) headingMap.set(selectionKey, { ...q, selectionKey, displayName: q.label, name: q.label, label: q.label, count: 0, chapters: new Set<number>(), aiVariants: [], lbaHeadings: new Set<string>() });
             headingMap.get(selectionKey).aiVariants.push({ ...q, marksPerQuestion: marks, name: q.label, label: q.label });
           });
         });
@@ -535,9 +537,9 @@ export class QuestionBankGenerationComponent implements OnInit, OnDestroy {
         const selectionKey = h.key;
         const headingName = h.label;
         const headingCount = Number(h.count);
-        if (!headingMap.has(selectionKey)) headingMap.set(selectionKey, { ...h, selectionKey, displayName: headingName, name: headingName, label: h.label, count: 0, chapters: new Set<number>(), aiVariants: [], lbaName: headingName });
+        if (!headingMap.has(selectionKey)) headingMap.set(selectionKey, { ...h, selectionKey, displayName: headingName, name: headingName, label: h.label, count: 0, chapters: new Set<number>(), aiVariants: [], lbaHeadings: new Set<string>() });
         const agg = headingMap.get(selectionKey)!;
-        agg.lbaName = headingName;
+        agg.lbaHeadings.add(h.name);
         agg.count += headingCount;
         agg.chapters.add(chapter.chapterNumber);
       }
@@ -551,7 +553,7 @@ export class QuestionBankGenerationComponent implements OnInit, OnDestroy {
         displayName: x.displayName,
         selectionKey: x.selectionKey,
         aiVariants: x.aiVariants,
-        lbaName: x.lbaName,
+        lbaHeadings: Array.from(x.lbaHeadings),
         count: x.count,
         chapters: Array.from(x.chapters).sort((a: any, b: any) => a - b)
       }))
@@ -762,13 +764,12 @@ export class QuestionBankGenerationComponent implements OnInit, OnDestroy {
           if (!heading) throw new Error(`Unexpected AI question block ${blockType}:${blockMarks}`);
 
           block.questions.forEach((q: any) => {
-            const text = blockType === 'MATCHING' ? `${q.value1} - ${q.value2}` : q.question;
+            const typedQuestion = { ...q, type: blockType };
             flatQuestions.push({
-              ...q,
+              ...typedQuestion,
               source: QUESTION_SOURCE.AI,
-              text,
+              text: questionContentItems(typedQuestion),
               marks: blockMarks,
-              type: blockType,
               heading: heading.label,
               unitName: chapterName,
               objective: q.objective,
@@ -869,7 +870,7 @@ export class QuestionBankGenerationComponent implements OnInit, OnDestroy {
 
     const selectedChapterNumbers = selectedChapters.map(ch => ch.chapterNumber);
     const selectedChapterIds = selectedChapters.map(ch => ch._id);
-    const selectedLBAHeadings = this.selectedHeadings.filter(h => h.lbaName).map(h => h.lbaName);
+    const selectedLBAHeadings = Array.from(new Set(this.selectedHeadings.flatMap(h => h.lbaHeadings || [])));
     if (!selectedLBAHeadings.length) return of([]);
 
     const params: any = {
@@ -935,16 +936,6 @@ export class QuestionBankGenerationComponent implements OnInit, OnDestroy {
       const matchesSearch = this.questionText(q).toLowerCase().includes(this.searchQuery);
       return matchesSource && matchesSearch;
     });
-  }
-
-  questionText(question: any): string {
-    const components = [];
-    if(question.type === 'MATCHING'){
-      components.push(...question.value1, {contentType: 'text/plain', content: '-'}, ...question.value2);
-    }else{
-      components.push(question.text);
-    }
-    return components.filter((item: any) => item.contentType === 'text/plain').map((item: any) => item.content).join(' ');
   }
 
   get isTotalMet(): boolean { return this.currentTotalMarks === this.totalMarks; }

--- a/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-template/question-bank-template.component.html
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-template/question-bank-template.component.html
@@ -118,6 +118,8 @@
         <div class="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-start mb-1">
           <p class="text-sm text-gray-800 line-clamp-3 group-hover:text-primary flex-1 sm:mr-2">{{ questionText(q) }}</p>
           <div class="flex flex-wrap items-center gap-1 sm:justify-end">
+            <img *ngIf="hasQuestionImage(q)" src="assets/icons/image.svg" [alt]="'Contains image' | translate"
+              [title]="'Contains image' | translate" class="w-4 h-4 text-gray-500" />
             <!-- New Heading Badge -->
             <span *ngIf="q.heading"
               class="text-[10px] font-bold px-1 rounded uppercase tracking-wider bg-purple-100 text-purple-700 border border-purple-200">
@@ -160,6 +162,8 @@
         <div class="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-start mb-1 pr-6">
           <p class="text-sm text-gray-800 flex-1 sm:mr-2">{{ questionText(q) }}</p>
           <div class="flex flex-wrap items-center gap-1 sm:justify-end">
+            <img *ngIf="hasQuestionImage(q)" src="assets/icons/image.svg" [alt]="'Contains image' | translate"
+              [title]="'Contains image' | translate" class="w-4 h-4 text-gray-500" />
             <!-- New Heading Badge -->
             <span *ngIf="q.heading"
               class="text-[10px] font-bold px-1 rounded uppercase tracking-wider bg-purple-100 text-purple-700 border border-purple-200">

--- a/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-template/question-bank-template.component.html
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-template/question-bank-template.component.html
@@ -116,7 +116,7 @@
         class="bg-white p-3 rounded border hover:shadow-md cursor-pointer transition-all border-l-4 group"
         [ngClass]="{'border-l-blue-500': q.source === QUESTION_SOURCE.AI, 'border-l-green-500': q.source === QUESTION_SOURCE.LBA}">
         <div class="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-start mb-1">
-          <p class="text-sm text-gray-800 line-clamp-3 group-hover:text-primary flex-1 sm:mr-2">{{ q.text }}</p>
+          <p class="text-sm text-gray-800 line-clamp-3 group-hover:text-primary flex-1 sm:mr-2">{{ questionText(q) }}</p>
           <div class="flex flex-wrap items-center gap-1 sm:justify-end">
             <!-- New Heading Badge -->
             <span *ngIf="q.heading"
@@ -158,7 +158,7 @@
         <button (click)="removeQuestion(i)"
           class="absolute top-2 right-2 text-gray-300 hover:text-red-500 font-bold text-xl leading-none">&times;</button>
         <div class="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-start mb-1 pr-6">
-          <p class="text-sm text-gray-800 flex-1 sm:mr-2">{{ q.text }}</p>
+          <p class="text-sm text-gray-800 flex-1 sm:mr-2">{{ questionText(q) }}</p>
           <div class="flex flex-wrap items-center gap-1 sm:justify-end">
             <!-- New Heading Badge -->
             <span *ngIf="q.heading"

--- a/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-template/question-bank-template.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-template/question-bank-template.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output, OnChanges, SimpleChanges } from '@angular/core';
 import { formatMarks, QUESTION_SOURCE } from 'src/app/shared/utility/constant.util';
-import { questionText } from 'src/app/shared/utility/question-bank-display.util';
+import { hasQuestionImage, questionText } from 'src/app/shared/utility/question-bank-display.util';
 
 @Component({
   selector: 'app-question-bank-template', // Keeping selector same for compatibility
@@ -40,6 +40,7 @@ export class QuestionBankTemplateComponent implements OnInit, OnChanges {
   availableDifficulties: string[] = [];
   readonly QUESTION_SOURCE = QUESTION_SOURCE;
   readonly formatMarks = formatMarks;
+  readonly hasQuestionImage = hasQuestionImage;
   readonly questionText = questionText;
 
   constructor() { }

--- a/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-template/question-bank-template.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-template/question-bank-template.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output, OnChanges, SimpleChanges } from '@angular/core';
 import { formatMarks, QUESTION_SOURCE } from 'src/app/shared/utility/constant.util';
+import { questionText } from 'src/app/shared/utility/question-bank-display.util';
 
 @Component({
   selector: 'app-question-bank-template', // Keeping selector same for compatibility
@@ -39,6 +40,7 @@ export class QuestionBankTemplateComponent implements OnInit, OnChanges {
   availableDifficulties: string[] = [];
   readonly QUESTION_SOURCE = QUESTION_SOURCE;
   readonly formatMarks = formatMarks;
+  readonly questionText = questionText;
 
   constructor() { }
 
@@ -154,16 +156,6 @@ export class QuestionBankTemplateComponent implements OnInit, OnChanges {
 
       return matchSource && matchDifficulty && matchType && matchSearch && !isSelected;
     });
-  }
-
-  questionText(question: any): string {
-    const components = [];
-    if(question.type === 'MATCHING'){
-      components.push(...question.value1, {contentType: 'text/plain', content: '-'}, ...question.value2);
-    }else{
-      components.push(question.text);
-    }
-    return components.filter((item: any) => item.contentType === 'text/plain').map((item: any) => item.content).join(' ');
   }
 
   onSearch(val: any) {

--- a/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-template/question-bank-template.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-generation/question-bank-template/question-bank-template.component.ts
@@ -147,13 +147,23 @@ export class QuestionBankTemplateComponent implements OnInit, OnChanges {
       const matchType = this.filterQuestionType === 'ALL' || q.heading === this.filterQuestionType;
 
       // 4. Search Filter
-      const matchSearch = !this.searchText || (q.text && q.text.toLowerCase().includes(this.searchText.toLowerCase()));
+      const matchSearch = !this.searchText || this.questionText(q).toLowerCase().includes(this.searchText.toLowerCase());
 
       // 5. Exclude already selected
       const isSelected = this.selectedQuestions.some(sq => sq._id === q._id);
 
       return matchSource && matchDifficulty && matchType && matchSearch && !isSelected;
     });
+  }
+
+  questionText(question: any): string {
+    const components = [];
+    if(question.type === 'MATCHING'){
+      components.push(...question.value1, {contentType: 'text/plain', content: '-'}, ...question.value2);
+    }else{
+      components.push(question.text);
+    }
+    return components.filter((item: any) => item.contentType === 'text/plain').map((item: any) => item.content).join(' ');
   }
 
   onSearch(val: any) {

--- a/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-view/question-bank-view.component.html
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-view/question-bank-view.component.html
@@ -117,13 +117,10 @@
                 *ngIf="questionBankData.type === 'MCQ'"
                 class="list-alpha">
                 <li *ngFor="let option of questionData.options">
-                  <ng-container *ngIf="option.text">
-                    <ng-container *ngFor="let item of contentItems(option.text)">
-                      <span *ngIf="isTextContent(item)">{{ item.content | mathFormatting }}</span>
-                      <img *ngIf="!isTextContent(item)" [src]="mediaSrc(item)" class="mt-1 max-h-32 max-w-full" />
-                    </ng-container>
+                  <ng-container *ngFor="let item of contentItems(option.text)">
+                    <span *ngIf="isTextContent(item)">{{ item.content | mathFormatting }}</span>
+                    <img *ngIf="!isTextContent(item)" [src]="mediaSrc(item)" class="mt-1 max-h-32 max-w-full" />
                   </ng-container>
-                  <span *ngIf="!option.text">{{ option | mathFormatting }}</span>
                 </li>
               </ul>
 

--- a/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-view/question-bank-view.component.html
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-view/question-bank-view.component.html
@@ -104,7 +104,11 @@
           ">
               <div class="flex justify-between items-start mt-2 gap-2">
                 <p class="text-content">
-                  {{ i + 1 }}. {{ questionData.question | mathFormatting }}
+                  {{ i + 1 }}.
+                  <ng-container *ngFor="let item of contentItems(questionData.question)">
+                    <span *ngIf="isTextContent(item)">{{ item.content | mathFormatting }}</span>
+                    <img *ngIf="!isTextContent(item)" [src]="mediaSrc(item)" class="mt-2 max-h-64 max-w-full" />
+                  </ng-container>
                 </p>
               </div>
 
@@ -113,7 +117,12 @@
                 *ngIf="questionBankData.type === 'MCQ'"
                 class="list-alpha">
                 <li *ngFor="let option of questionData.options">
-                  <span *ngIf="option.text">{{ option.text | mathFormatting }}</span>
+                  <ng-container *ngIf="option.text">
+                    <ng-container *ngFor="let item of contentItems(option.text)">
+                      <span *ngIf="isTextContent(item)">{{ item.content | mathFormatting }}</span>
+                      <img *ngIf="!isTextContent(item)" [src]="mediaSrc(item)" class="mt-1 max-h-32 max-w-full" />
+                    </ng-container>
+                  </ng-container>
                   <span *ngIf="!option.text">{{ option | mathFormatting }}</span>
                 </li>
               </ul>
@@ -121,7 +130,12 @@
               <div *ngIf="showAnswerKeys && questionData.keyAnswer"
                 class="mt-1 mb-3 ml-4 px-3 py-2 bg-green-50 border border-green-200 rounded-md">
                 <span class="text-xs font-bold text-green-700 uppercase tracking-wider">{{ "Answer" | translate }}:</span>
-                <span class="ml-2 text-sm text-green-800 font-medium">{{ questionData.keyAnswer }}</span>
+                <span class="ml-2 text-sm text-green-800 font-medium">
+                  <ng-container *ngFor="let item of contentItems(questionData.keyAnswer)">
+                    <span *ngIf="isTextContent(item)">{{ item.content }}</span>
+                    <img *ngIf="!isTextContent(item)" [src]="mediaSrc(item)" class="mt-1 max-h-32 max-w-full" />
+                  </ng-container>
+                </span>
               </div>
             </div>
           </div>
@@ -130,10 +144,16 @@
               <tbody>
                 <tr *ngFor="let val of questionBankData.questions; let i=index">
                   <td class="border px-2 py-2 text-sm">
-                    {{ (questionBankData.primaryColumn ? questionBankData.primaryColumn[i] : '') | mathFormatting }}
+                    <ng-container *ngFor="let item of contentItems(questionBankData.primaryColumn[i])">
+                      <span *ngIf="isTextContent(item)">{{ item.content | mathFormatting }}</span>
+                      <img *ngIf="!isTextContent(item)" [src]="mediaSrc(item)" class="mt-1 max-h-32 max-w-full" />
+                    </ng-container>
                   </td>
                   <td class="border px-2 py-2 text-sm">
-                    {{ (questionBankData.shuffledColumns ? questionBankData.shuffledColumns[i] : '') | mathFormatting }}
+                    <ng-container *ngFor="let item of contentItems(questionBankData.shuffledColumns[i])">
+                      <span *ngIf="isTextContent(item)">{{ item.content | mathFormatting }}</span>
+                      <img *ngIf="!isTextContent(item)" [src]="mediaSrc(item)" class="mt-1 max-h-32 max-w-full" />
+                    </ng-container>
                   </td>
                 </tr>
               </tbody>
@@ -150,10 +170,16 @@
                 <tbody>
                   <tr *ngFor="let val of questionBankData.questions; let i=index">
                     <td class="border border-green-200 px-2 py-1 text-sm text-green-800">
-                      {{ questionBankData.primaryColumn?.[i] || '' }}
+                      <ng-container *ngFor="let item of contentItems(questionBankData.primaryColumn[i])">
+                        <span *ngIf="isTextContent(item)">{{ item.content }}</span>
+                        <img *ngIf="!isTextContent(item)" [src]="mediaSrc(item)" class="mt-1 max-h-24 max-w-full" />
+                      </ng-container>
                     </td>
                     <td class="border border-green-200 px-2 py-1 text-sm text-green-800 font-medium">
-                      {{ questionBankData.originalColumns?.[i] || '' }}
+                      <ng-container *ngFor="let item of contentItems(questionBankData.originalColumns[i])">
+                        <span *ngIf="isTextContent(item)">{{ item.content }}</span>
+                        <img *ngIf="!isTextContent(item)" [src]="mediaSrc(item)" class="mt-1 max-h-24 max-w-full" />
+                      </ng-container>
                     </td>
                   </tr>
                 </tbody>

--- a/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-view/question-bank-view.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-view/question-bank-view.component.ts
@@ -7,6 +7,7 @@ import { IdleService } from 'src/app/shared/services/idle.service';
 import { QuestionBankDownloadService } from 'src/app/shared/services/question-bank-download.service';
 import { BluePrintExportService } from 'src/app/shared/services/blue-print.export.service';
 import { formatMarks } from 'src/app/shared/utility/constant.util';
+import { contentItems } from 'src/app/shared/utility/question-bank-display.util';
 @Component({
   selector: 'app-question-bank-view',
   templateUrl: './question-bank-view.component.html',
@@ -48,6 +49,7 @@ export class QuestionBankViewComponent implements OnInit {
   questionTypeLabels: Record<string, string> = {};
   generatedTotalMarks = 0;
   readonly formatMarks = formatMarks;
+  readonly contentItems = contentItems;
 
   docTypes = [
     {
@@ -144,10 +146,6 @@ export class QuestionBankViewComponent implements OnInit {
     });
 
     return result;
-  }
-
-  contentItems(content: any): any[] {
-    return Array.isArray(content) ? content : [{ contentType: 'text/plain', content }];
   }
 
   isTextContent(item: any): boolean {

--- a/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-view/question-bank-view.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/view/user/question-bank/question-bank-view/question-bank-view.component.ts
@@ -146,6 +146,18 @@ export class QuestionBankViewComponent implements OnInit {
     return result;
   }
 
+  contentItems(content: any): any[] {
+    return Array.isArray(content) ? content : [{ contentType: 'text/plain', content }];
+  }
+
+  isTextContent(item: any): boolean {
+    return item.contentType === 'text/plain';
+  }
+
+  mediaSrc(item: any): string {
+    return `data:${item.contentType};base64,${item.content}`;
+  }
+
   download(type: any) {
     if (type === 'qp') {
       this.downloadQp()

--- a/shiksha-website/shiksha-frontend/src/assets/i18n/en.json
+++ b/shiksha-website/shiksha-frontend/src/assets/i18n/en.json
@@ -508,5 +508,6 @@
   "Pre-generated Questions": "Pre-generated Questions",
   "Easy": "Easy",
   "Average": "Average",
-  "Difficult": "Difficult"
+  "Difficult": "Difficult",
+  "Contains image": "Contains image"
 }

--- a/shiksha-website/shiksha-frontend/src/assets/i18n/kn.json
+++ b/shiksha-website/shiksha-frontend/src/assets/i18n/kn.json
@@ -501,5 +501,6 @@
   "Pre-generated Questions": "ಪೂರ್ವ-ರಚಿತ ಪ್ರಶ್ನೆಗಳು",
   "Easy": "ಸುಲಭ",
   "Average": "ಸರಾಸರಿ",
-  "Difficult": "ಕಷ್ಟ"
+  "Difficult": "ಕಷ್ಟ",
+  "Contains image": "ಚಿತ್ರವನ್ನು ಒಳಗೊಂಡಿದೆ"
 }

--- a/shiksha-website/shiksha-frontend/src/assets/i18n/tg.json
+++ b/shiksha-website/shiksha-frontend/src/assets/i18n/tg.json
@@ -508,5 +508,6 @@
   "Pre-generated Questions": "ముందుగా రూపొందించిన ప్రశ్నలు",
   "Easy": "సులభం",
   "Average": "సగటు",
-  "Difficult": "కష్టం"
+  "Difficult": "కష్టం",
+  "Contains image": "చిత్రాన్ని కలిగి ఉంది"
 }

--- a/shiksha-website/shiksha-frontend/src/assets/icons/image.svg
+++ b/shiksha-website/shiksha-frontend/src/assets/icons/image.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="1.5" y="2.5" width="13" height="11" rx="1.5" stroke="currentColor"/>
+  <circle cx="5" cy="6" r="1.25" fill="currentColor"/>
+  <path d="M2 12L6 8.5L8.5 10.5L10.5 8.5L14 12" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Introduction
Introduces support for images by replacing `question: str` with a powerful `question: list[Content]`. Content can support any arbitrary media type. Data transformation logic for legacy -> new format resides in `transformWeakLbaQuestion`.

Here is a before after of how questions are structured:
```py
# before
"What is photosynthesis?"

# after
[
  {"content_type": "text/plain", "What is photosynthesis?"
]
```

This is more powerful than merely adding an `image: bytes` field, because this lets us interleave textual and image content. E.g.,
```py
question = [  # ordered list
  {"content_type": "text/plain", "What is photosynthesis?"},
  {"content_type": "image/png", "data:image/png;base64,..."},
  {"content_type": "text/plain", "What does the image above show about how photosynthesis works?"},
]
```

This change in question format `str -> list[Content]` covers all properties of question, including options for mcqs, left and right sides for match the following, and even keyAnswer fields.

## Preview
<img width="1512" height="698" alt="image" src="https://github.com/user-attachments/assets/acaaddc9-8f45-42d6-8afd-2480ce70cfa5" />
<p align="center">An image icon indicates whether a question includes visuals.</p>

<img width="1917" height="938" alt="image" src="https://github.com/user-attachments/assets/bf0122c4-4890-40f4-8bf4-b72ea0121c40" />
<p align="center">On the next step, user gets to preview the actual image. At this stage, they can go back and reselect the image without invoking question regeneration.</p>

<img width="1919" height="941" alt="image" src="https://github.com/user-attachments/assets/a7613dd7-ab33-4549-9179-ee784d9c5155" />
<p align="center">Final question paper preview with the images embedded in the question paper.</p>

