### PR TITLE
fix(ingestion): write indexPath back to MongoDB after Qdrant indexing

### DIFF
--- a/shiksha-ingestion/pipeline_steps/step_8_create_indexes.py
+++ b/shiksha-ingestion/pipeline_steps/step_8_create_indexes.py
@@ -10,8 +10,8 @@ from llama_index.core.node_parser import MarkdownNodeParser, SentenceSplitter
 from ingestion_pipeline.base.pipeline import BasePipelineStep, StepResult, StepStatus
 from qdrant_client import AsyncQdrantClient
 from qdrant_client.models import PayloadSchemaType
+from pymongo import AsyncMongoClient
 import asyncio
-import motor.motor_asyncio
 
 load_dotenv(".env")
 
@@ -28,7 +28,7 @@ class CreateIndexStep(BasePipelineStep):
     description = "Create Index for chapter markdown file"
     input_types = {"markdown"}
     output_types = {"index_filter"}
-    
+
     def _split_by_pages(self, content):
         """
         Split the content into pages using delimiters of the form '## Page <number>'.
@@ -62,7 +62,7 @@ class CreateIndexStep(BasePipelineStep):
             azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
             api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2025-03-01-preview"),
         )
-    
+
     def _get_rag_ops_instance(self, collection_name: str):
         """Get an instance of QdrantRagOps with the specified collection name."""
         return QdrantRagOps(
@@ -89,16 +89,16 @@ class CreateIndexStep(BasePipelineStep):
             with open(markdown_file, "r", encoding="utf-8") as file:
                 markdown_content = file.read()
             pages = self._split_by_pages(markdown_content)
-            
+
             board = self.config.get("board", "KSEEB")
             medium = self.config.get("medium", "english")
             grade = self.config.get("grade", 6)
             subject = self.config.get("subject", "science")
             chapter_number = self.config.get("chapter_number", 1)
             chapter_id = f"Medium={medium},Grade={grade},Subject={subject},Number={chapter_number}"
-    
-            rag_ops = self._get_rag_ops_instance(collection_name=board)
             index_path = f"qdrant/{board}/chapter_id:{chapter_id}"
+
+            rag_ops = self._get_rag_ops_instance(collection_name=board)
 
             async def run_create_index():
                 transformations = [
@@ -130,7 +130,7 @@ class CreateIndexStep(BasePipelineStep):
                 mongo_url = os.getenv("MONGO_URL")
                 if mongo_url:
                     mongo_board = board.replace("_", "-")
-                    mongo_client = motor.motor_asyncio.AsyncIOMotorClient(mongo_url)
+                    mongo_client = AsyncMongoClient(mongo_url)
                     db = mongo_client.get_default_database()
                     result = await db.chapters.update_one(
                         {
@@ -153,7 +153,7 @@ class CreateIndexStep(BasePipelineStep):
                     logger.warning("MONGO_URL not set — skipping indexPath write-back to MongoDB")
 
             asyncio.run(run_create_index())
-            
+
             return StepResult(
                 status=StepStatus.COMPLETED,
                 output_paths={
@@ -168,9 +168,7 @@ class CreateIndexStep(BasePipelineStep):
                     "chapter_id": chapter_id
                 }
             )
-        
+
         except Exception as e:
             logger.error(f"Error processing markdown file {markdown_file}: {e}")
             return StepResult(status=StepStatus.FAILED, error=str(e))
-        
-        

--- a/shiksha-ingestion/pipeline_steps/step_8_create_indexes.py
+++ b/shiksha-ingestion/pipeline_steps/step_8_create_indexes.py
@@ -8,6 +8,8 @@ from llama_index.llms.azure_openai import AzureOpenAI
 from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
 from llama_index.core.node_parser import MarkdownNodeParser, SentenceSplitter
 from ingestion_pipeline.base.pipeline import BasePipelineStep, StepResult, StepStatus
+from qdrant_client import AsyncQdrantClient
+from qdrant_client.models import PayloadSchemaType
 import asyncio
 import motor.motor_asyncio
 
@@ -111,12 +113,22 @@ class CreateIndexStep(BasePipelineStep):
                     transformations=transformations
                 )
 
-                # Write indexPath back to MongoDB so the backend knows which
-                # Qdrant collection to query for this chapter.
+                # Ensure chapter_id payload index exists for filtered queries
+                qdrant_client = AsyncQdrantClient(
+                    url=os.getenv("QDRANT_URL", "http://localhost:6333"),
+                    api_key=os.getenv("QDRANT_API_KEY"),
+                )
+                await qdrant_client.create_payload_index(
+                    collection_name=board,
+                    field_name="chapter_id",
+                    field_schema=PayloadSchemaType.KEYWORD,
+                )
+
+                # Write indexPath back to MongoDB so the backend routes to the
+                # correct Qdrant collection for this chapter.
+                # Qdrant collection uses underscores (BSE_TG); MongoDB board field uses dashes (BSE-TG).
                 mongo_url = os.getenv("MONGO_URL")
                 if mongo_url:
-                    # Qdrant collection name uses underscores (BSE_TG) but
-                    # MongoDB board field uses dashes (BSE-TG).
                     mongo_board = board.replace("_", "-")
                     mongo_client = motor.motor_asyncio.AsyncIOMotorClient(mongo_url)
                     db = mongo_client.get_default_database()

--- a/shiksha-ingestion/pipeline_steps/step_8_create_indexes.py
+++ b/shiksha-ingestion/pipeline_steps/step_8_create_indexes.py
@@ -114,68 +114,79 @@ class CreateIndexStep(BasePipelineStep):
                 )
 
                 # Ensure chapter_id payload index exists for filtered queries.
+                # Best-effort: a failure here must not fail the step since create_index already succeeded.
                 # Close in finally to avoid a connection leak per chapter.
-                qdrant_client = AsyncQdrantClient(
-                    url=os.getenv("QDRANT_URL", "http://localhost:6333"),
-                    api_key=os.getenv("QDRANT_API_KEY"),
-                )
                 try:
-                    await qdrant_client.create_payload_index(
-                        collection_name=board,
-                        field_name="chapter_id",
-                        field_schema=PayloadSchemaType.KEYWORD,
+                    qdrant_client = AsyncQdrantClient(
+                        url=os.getenv("QDRANT_URL", "http://localhost:6333"),
+                        api_key=os.getenv("QDRANT_API_KEY"),
                     )
-                finally:
-                    await qdrant_client.close()
+                    try:
+                        await qdrant_client.create_payload_index(
+                            collection_name=board,
+                            field_name="chapter_id",
+                            field_schema=PayloadSchemaType.KEYWORD,
+                        )
+                    finally:
+                        await qdrant_client.close()
+                except Exception as e:
+                    logger.warning(f"Failed to create chapter_id payload index (non-fatal): {e}")
 
                 # Write indexPath back to MongoDB so the backend routes to the
                 # correct Qdrant collection for this chapter.
+                # Best-effort: a failure here must not fail the step since create_index already succeeded.
+                # MONGO_URL must include the database name (e.g. mongodb://host:27017/mydb).
                 # Qdrant collection uses underscores (BSE_TG); MongoDB board field uses dashes (BSE-TG).
-                mongo_url = os.getenv("MONGO_URL")
-                if not mongo_url:
-                    logger.warning("MONGO_URL not set — skipping indexPath write-back to MongoDB")
-                    return
-
-                mongo_board = board.replace("_", "-")
-                mongo_client = AsyncMongoClient(mongo_url)
                 try:
-                    db = mongo_client.get_default_database()
-
-                    # Chapter docs store subject as subjectId (ObjectId ref to MasterSubject),
-                    # not a plain string — resolve it first to avoid matching the wrong chapter.
-                    master_subject = await db.mastersubjects.find_one(
-                        {"subjectName": {"$regex": f"^{subject}$", "$options": "i"}},
-                        {"_id": 1},
-                    )
-                    if not master_subject:
-                        logger.warning(
-                            f"MasterSubject not found for subject={subject} "
-                            f"— skipping indexPath write-back"
-                        )
+                    mongo_url = os.getenv("MONGO_URL")
+                    if not mongo_url:
+                        logger.warning("MONGO_URL not set — skipping indexPath write-back to MongoDB")
                         return
 
-                    result = await db.chapters.update_one(
-                        {
-                            "board": mongo_board,
-                            "medium": medium,
-                            "standard": int(grade),
-                            "orderNumber": int(chapter_number),
-                            "subjectId": master_subject["_id"],
-                        },
-                        {"$set": {"indexPath": index_path}},
-                    )
+                    mongo_board = board.replace("_", "-")
+                    mongo_client = AsyncMongoClient(mongo_url)
+                    try:
+                        db = mongo_client.get_default_database()
 
-                    if result.matched_count == 0:
-                        logger.warning(
-                            f"No chapter found in MongoDB for board={mongo_board} "
-                            f"medium={medium} grade={grade} subject={subject} chapter={chapter_number}"
+                        # Chapter docs store subject as subjectId (ObjectId ref to MasterSubject),
+                        # not a plain string — resolve it first to avoid matching the wrong chapter.
+                        # Use re.escape to handle any regex metacharacters in subject name.
+                        master_subject = await db.mastersubjects.find_one(
+                            {"subjectName": {"$regex": f"^{re.escape(subject.strip())}$", "$options": "i"}},
+                            {"_id": 1},
                         )
-                    elif result.modified_count:
-                        logger.info(f"Updated indexPath in MongoDB: {index_path}")
-                    else:
-                        logger.info(f"indexPath already correct in MongoDB: {index_path}")
-                finally:
-                    await mongo_client.close()
+                        if not master_subject:
+                            logger.warning(
+                                f"MasterSubject not found for subject={subject} "
+                                f"— skipping indexPath write-back"
+                            )
+                            return
+
+                        result = await db.chapters.update_one(
+                            {
+                                # Match case-insensitively, consistent with chapter.dao.js regexExact.
+                                "board": {"$regex": f"^{re.escape(mongo_board.strip())}$", "$options": "i"},
+                                "medium": {"$regex": f"^{re.escape(medium.strip())}$", "$options": "i"},
+                                "standard": int(grade),
+                                "orderNumber": int(chapter_number),
+                                "subjectId": master_subject["_id"],
+                            },
+                            {"$set": {"indexPath": index_path}},
+                        )
+
+                        if result.matched_count == 0:
+                            logger.warning(
+                                f"No chapter found in MongoDB for board={mongo_board} "
+                                f"medium={medium} grade={grade} subject={subject} chapter={chapter_number}"
+                            )
+                        elif result.modified_count:
+                            logger.info(f"Updated indexPath in MongoDB: {index_path}")
+                        else:
+                            logger.info(f"indexPath already correct in MongoDB: {index_path}")
+                    finally:
+                        await mongo_client.close()
+                except Exception as e:
+                    logger.warning(f"MongoDB indexPath write-back failed (non-fatal): {e}")
 
             asyncio.run(run_create_index())
 

--- a/shiksha-ingestion/pipeline_steps/step_8_create_indexes.py
+++ b/shiksha-ingestion/pipeline_steps/step_8_create_indexes.py
@@ -1,17 +1,15 @@
-import json
 import logging
 import os
 import re
-from textwrap import dedent
-from typing import Dict, List, Any
+from typing import Dict
 from dotenv import load_dotenv
-from pydantic import BaseModel, Field
 from rag_wrapper.rag_ops.qdrant_rag_ops import QdrantRagOps
 from llama_index.llms.azure_openai import AzureOpenAI
 from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
 from llama_index.core.node_parser import MarkdownNodeParser, SentenceSplitter
 from ingestion_pipeline.base.pipeline import BasePipelineStep, StepResult, StepStatus
 import asyncio
+import motor.motor_asyncio
 
 load_dotenv(".env")
 
@@ -98,7 +96,8 @@ class CreateIndexStep(BasePipelineStep):
             chapter_id = f"Medium={medium},Grade={grade},Subject={subject},Number={chapter_number}"
     
             rag_ops = self._get_rag_ops_instance(collection_name=board)
-            
+            index_path = f"qdrant/{board}/chapter_id:{chapter_id}"
+
             async def run_create_index():
                 transformations = [
                     MarkdownNodeParser(),
@@ -111,6 +110,35 @@ class CreateIndexStep(BasePipelineStep):
                     },
                     transformations=transformations
                 )
+
+                # Write indexPath back to MongoDB so the backend knows which
+                # Qdrant collection to query for this chapter.
+                mongo_url = os.getenv("MONGO_URL")
+                if mongo_url:
+                    # Qdrant collection name uses underscores (BSE_TG) but
+                    # MongoDB board field uses dashes (BSE-TG).
+                    mongo_board = board.replace("_", "-")
+                    mongo_client = motor.motor_asyncio.AsyncIOMotorClient(mongo_url)
+                    db = mongo_client.get_default_database()
+                    result = await db.chapters.update_one(
+                        {
+                            "board": mongo_board,
+                            "medium": medium,
+                            "standard": grade,
+                            "orderNumber": chapter_number,
+                        },
+                        {"$set": {"indexPath": index_path}},
+                    )
+                    mongo_client.close()
+                    if result.modified_count:
+                        logger.info(f"Updated indexPath in MongoDB: {index_path}")
+                    else:
+                        logger.warning(
+                            f"No chapter updated in MongoDB for board={mongo_board} "
+                            f"medium={medium} grade={grade} chapter={chapter_number}"
+                        )
+                else:
+                    logger.warning("MONGO_URL not set — skipping indexPath write-back to MongoDB")
 
             asyncio.run(run_create_index())
             

--- a/shiksha-ingestion/pipeline_steps/step_8_create_indexes.py
+++ b/shiksha-ingestion/pipeline_steps/step_8_create_indexes.py
@@ -30,10 +30,18 @@ class CreateIndexStep(BasePipelineStep):
     output_types = {"index_filter"}
 
     def _split_by_pages(self, content):
+        """
+        Split the content into pages using delimiters of the form '## Page <number>'.
+        Returns a list of strings, one per page.
+        """
+        # Split on lines starting with '## Page <number>'
+        # Handles both start-of-file and anywhere in the file
         pages = re.split(r'^##\s*Page\s*\d+\s*$', content, flags=re.MULTILINE)
+        # Remove empty or whitespace-only pages
         return [page.strip() for page in pages if page.strip()]
 
     def _embedding_llm(self):
+        """Initialize Azure OpenAI embedding model"""
         return AzureOpenAIEmbedding(
             model=os.getenv("AZURE_OPENAI_EMBEDDING_MODEL", "text-embedding-ada-002"),
             deployment_name=os.getenv(
@@ -44,7 +52,9 @@ class CreateIndexStep(BasePipelineStep):
             api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2025-03-01-preview"),
         )
 
+
     def _completion_llm(self):
+        """Initialize Azure OpenAI completion model"""
         return AzureOpenAI(
             model=os.getenv("AZURE_OPENAI_MODEL", "gpt-35-turbo"),
             deployment_name=os.getenv("AZURE_OPENAI_MODEL", "gpt-35-turbo"),
@@ -54,6 +64,7 @@ class CreateIndexStep(BasePipelineStep):
         )
 
     def _get_rag_ops_instance(self, collection_name: str):
+        """Get an instance of QdrantRagOps with the specified collection name."""
         return QdrantRagOps(
             url=os.getenv("QDRANT_URL", "http://localhost:6333"),
             collection_name=collection_name,
@@ -62,6 +73,17 @@ class CreateIndexStep(BasePipelineStep):
         )
 
     def process(self, input_paths: Dict[str, str], output_dir: str) -> StepResult:
+        """
+        Process the step - create indexes from chapter markdown content.
+
+        Args:
+            input_paths: Dictionary with keys:
+                - "markdown": Path to the cleaned markdown file
+            index_filter: index metadata filter
+
+        Returns:
+            StepResult with status and output paths containing the index_filter
+        """
         try:
             markdown_file = input_paths["markdown"]
             with open(markdown_file, "r", encoding="utf-8") as file:
@@ -85,7 +107,9 @@ class CreateIndexStep(BasePipelineStep):
                 ]
                 await rag_ops.create_index(
                     text_chunks=pages,
-                    metadata={"chapter_id": chapter_id},
+                    metadata={
+                        "chapter_id": chapter_id
+                    },
                     transformations=transformations
                 )
 
@@ -173,3 +197,5 @@ class CreateIndexStep(BasePipelineStep):
         except Exception as e:
             logger.error(f"Error processing markdown file {markdown_file}: {e}")
             return StepResult(status=StepStatus.FAILED, error=str(e))
+
+

--- a/shiksha-ingestion/pipeline_steps/step_8_create_indexes.py
+++ b/shiksha-ingestion/pipeline_steps/step_8_create_indexes.py
@@ -30,18 +30,10 @@ class CreateIndexStep(BasePipelineStep):
     output_types = {"index_filter"}
 
     def _split_by_pages(self, content):
-        """
-        Split the content into pages using delimiters of the form '## Page <number>'.
-        Returns a list of strings, one per page.
-        """
-        # Split on lines starting with '## Page <number>'
-        # Handles both start-of-file and anywhere in the file
         pages = re.split(r'^##\s*Page\s*\d+\s*$', content, flags=re.MULTILINE)
-        # Remove empty or whitespace-only pages
         return [page.strip() for page in pages if page.strip()]
 
     def _embedding_llm(self):
-        """Initialize Azure OpenAI embedding model"""
         return AzureOpenAIEmbedding(
             model=os.getenv("AZURE_OPENAI_EMBEDDING_MODEL", "text-embedding-ada-002"),
             deployment_name=os.getenv(
@@ -52,9 +44,7 @@ class CreateIndexStep(BasePipelineStep):
             api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2025-03-01-preview"),
         )
 
-
     def _completion_llm(self):
-        """Initialize Azure OpenAI completion model"""
         return AzureOpenAI(
             model=os.getenv("AZURE_OPENAI_MODEL", "gpt-35-turbo"),
             deployment_name=os.getenv("AZURE_OPENAI_MODEL", "gpt-35-turbo"),
@@ -64,7 +54,6 @@ class CreateIndexStep(BasePipelineStep):
         )
 
     def _get_rag_ops_instance(self, collection_name: str):
-        """Get an instance of QdrantRagOps with the specified collection name."""
         return QdrantRagOps(
             url=os.getenv("QDRANT_URL", "http://localhost:6333"),
             collection_name=collection_name,
@@ -73,17 +62,6 @@ class CreateIndexStep(BasePipelineStep):
         )
 
     def process(self, input_paths: Dict[str, str], output_dir: str) -> StepResult:
-        """
-        Process the step - create indexes from chapter markdown content.
-
-        Args:
-            input_paths: Dictionary with keys:
-                - "markdown": Path to the cleaned markdown file
-            index_filter: index metadata filter
-
-        Returns:
-            StepResult with status and output paths containing the index_filter
-        """
         try:
             markdown_file = input_paths["markdown"]
             with open(markdown_file, "r", encoding="utf-8") as file:
@@ -107,50 +85,73 @@ class CreateIndexStep(BasePipelineStep):
                 ]
                 await rag_ops.create_index(
                     text_chunks=pages,
-                    metadata={
-                        "chapter_id": chapter_id
-                    },
+                    metadata={"chapter_id": chapter_id},
                     transformations=transformations
                 )
 
-                # Ensure chapter_id payload index exists for filtered queries
+                # Ensure chapter_id payload index exists for filtered queries.
+                # Close in finally to avoid a connection leak per chapter.
                 qdrant_client = AsyncQdrantClient(
                     url=os.getenv("QDRANT_URL", "http://localhost:6333"),
                     api_key=os.getenv("QDRANT_API_KEY"),
                 )
-                await qdrant_client.create_payload_index(
-                    collection_name=board,
-                    field_name="chapter_id",
-                    field_schema=PayloadSchemaType.KEYWORD,
-                )
+                try:
+                    await qdrant_client.create_payload_index(
+                        collection_name=board,
+                        field_name="chapter_id",
+                        field_schema=PayloadSchemaType.KEYWORD,
+                    )
+                finally:
+                    await qdrant_client.close()
 
                 # Write indexPath back to MongoDB so the backend routes to the
                 # correct Qdrant collection for this chapter.
                 # Qdrant collection uses underscores (BSE_TG); MongoDB board field uses dashes (BSE-TG).
                 mongo_url = os.getenv("MONGO_URL")
-                if mongo_url:
-                    mongo_board = board.replace("_", "-")
-                    mongo_client = AsyncMongoClient(mongo_url)
+                if not mongo_url:
+                    logger.warning("MONGO_URL not set — skipping indexPath write-back to MongoDB")
+                    return
+
+                mongo_board = board.replace("_", "-")
+                mongo_client = AsyncMongoClient(mongo_url)
+                try:
                     db = mongo_client.get_default_database()
+
+                    # Chapter docs store subject as subjectId (ObjectId ref to MasterSubject),
+                    # not a plain string — resolve it first to avoid matching the wrong chapter.
+                    master_subject = await db.mastersubjects.find_one(
+                        {"subjectName": {"$regex": f"^{subject}$", "$options": "i"}},
+                        {"_id": 1},
+                    )
+                    if not master_subject:
+                        logger.warning(
+                            f"MasterSubject not found for subject={subject} "
+                            f"— skipping indexPath write-back"
+                        )
+                        return
+
                     result = await db.chapters.update_one(
                         {
                             "board": mongo_board,
                             "medium": medium,
-                            "standard": grade,
-                            "orderNumber": chapter_number,
+                            "standard": int(grade),
+                            "orderNumber": int(chapter_number),
+                            "subjectId": master_subject["_id"],
                         },
                         {"$set": {"indexPath": index_path}},
                     )
-                    mongo_client.close()
-                    if result.modified_count:
+
+                    if result.matched_count == 0:
+                        logger.warning(
+                            f"No chapter found in MongoDB for board={mongo_board} "
+                            f"medium={medium} grade={grade} subject={subject} chapter={chapter_number}"
+                        )
+                    elif result.modified_count:
                         logger.info(f"Updated indexPath in MongoDB: {index_path}")
                     else:
-                        logger.warning(
-                            f"No chapter updated in MongoDB for board={mongo_board} "
-                            f"medium={medium} grade={grade} chapter={chapter_number}"
-                        )
-                else:
-                    logger.warning("MONGO_URL not set — skipping indexPath write-back to MongoDB")
+                        logger.info(f"indexPath already correct in MongoDB: {index_path}")
+                finally:
+                    await mongo_client.close()
 
             asyncio.run(run_create_index())
 

--- a/shiksha-ingestion/pyproject.toml
+++ b/shiksha-ingestion/pyproject.toml
@@ -15,7 +15,7 @@ requests = "^2.32.4"
 tqdm = "^4.67.1"
 openpyxl = "^3.1.5"
 azure-storage-blob = "^12.26.0"
-pymongo = "^4.7.0"
+pymongo = "^4.9.0"
 qdrant-client = ">=1.7.0"
 # Knowledge Graph and Visualization Dependencies
 networkx = "^3.0"

--- a/shiksha-ingestion/pyproject.toml
+++ b/shiksha-ingestion/pyproject.toml
@@ -15,6 +15,8 @@ requests = "^2.32.4"
 tqdm = "^4.67.1"
 openpyxl = "^3.1.5"
 azure-storage-blob = "^12.26.0"
+pymongo = "^4.7.0"
+qdrant-client = ">=1.7.0"
 # Knowledge Graph and Visualization Dependencies
 networkx = "^3.0"
 matplotlib = "^3.7.0"


### PR DESCRIPTION
## Summary

- `step_8_create_indexes.py` was indexing chapter chunks into the correct board-specific Qdrant collection (`BSE_TG`, `KSEEB`, etc.) but never writing the `indexPath` back to MongoDB
- This caused the backend to send stale/wrong `index_path` to durable functions, which then queried the wrong Qdrant collection (`SCERT`) for BSE-TG chapters — resulting in retrieval failure
- After `create_index` succeeds, an async `updateOne` now writes `indexPath = "qdrant/<board>/chapter_id:<chapter_id>"` to the matching chapter document in MongoDB

## Related issue

Closes #223 — Segment Qdrant into sub collections

## Data migrations run (one-time, not in this PR)

- Rebuilt `BSE_TG` collection on staging Qdrant by scrolling SCERT and copying all 6908 BSE-TG chunks (identified via MongoDB `indexPath`)
- Fixed 151 BSE-TG chapter documents in MongoDB: `qdrant/SCERT/` → `qdrant/BSE_TG/` in `indexPath` field

## Config required

`MONGO_URL` must be set in the ingestion `.env` for write-back to work. If absent, indexing still succeeds but a warning is logged.

## Test plan

- [ ] Run `step_8_create_indexes.py` for a BSE-TG chapter with `MONGO_URL` set — verify `indexPath` appears in MongoDB as `qdrant/BSE_TG/chapter_id:...`
- [ ] Run same without `MONGO_URL` — verify indexing succeeds with warning logged, no crash
- [ ] Verify staging Qdrant `BSE_TG` collection has 6908 points
- [ ] Generate a lesson plan for a BSE-TG chapter — verify it no longer errors on wrong collection