### PR TITLE
qp: fix translator endpoint breaks question structure

### DIFF
--- a/shiksha-api/app-service/app/services/translation_service.py
+++ b/shiksha-api/app-service/app/services/translation_service.py
@@ -9,7 +9,19 @@ MAX_RECURSION_DEPTH = 50
 TRANSLATION_BATCH_SIZE = 100
 # Keys whose values are semantic identifiers (enums, codes) used for logic/styling,
 # not human-readable content. Translating these would break downstream consumers.
-SKIP_KEYS: frozenset = frozenset({"type", "heading", "source", "difficulty", "objective", "unit_name"})
+SKIP_KEYS: frozenset = frozenset({
+    "type", "heading", "source", "difficulty", "objective", "unit_name", "answer_type", "_id",
+    "correct_order_indices", "year", "correct_order_by_id", "exam_type", "chapter_number", "content_type",
+    "marks_per_question", "title", "medium", "language", "chapter_id", "subject", "chapter", "class"
+})
+
+
+def _skip(data: dict, key: str) -> bool:
+    if key in SKIP_KEYS:
+        return True
+    if key == "content" and "content_type" in data and data["content_type"].startswith("image/"):
+        return True
+    return False
 
 
 class TranslationService:
@@ -55,7 +67,7 @@ class TranslationService:
         if isinstance(data, dict):
             out: List[str] = []
             for key, value in data.items():
-                if key in SKIP_KEYS:
+                if _skip(data, key):
                     continue
                 if isinstance(value, str):
                     out.append(value)
@@ -96,7 +108,7 @@ class TranslationService:
         if isinstance(data, dict):
             return {
                 key: value
-                if key in SKIP_KEYS
+                if _skip(data, key)
                 else cls._fill_strings(value, translations, depth + 1)
                 if not isinstance(value, str)
                 else cls._next_translated(translations, value)


### PR DESCRIPTION
## Summary
Translator endpoint breaks question paper structure. It does not preserve key information, often translating answer type ("Match the following", "Fill in the blanks") and source ("LBA"). In addition, recent image support overlooked this section - translator service at present would not skip image content.

## Preview
<img width="1919" height="941" alt="image" src="https://github.com/user-attachments/assets/6f3adcd2-645b-4be7-9c8b-56e63128e181" />
<p align="center">Translated questions once again appear in Step 2</p>

<img width="1917" height="941" alt="image" src="https://github.com/user-attachments/assets/6b5b5f02-e1ed-4fe2-b260-52d69134bc5b" />
<p align="center">Preview retains translation strings, and the translation works as intended on visual questions (only the text gets translated)</p>

<img width="1919" height="940" alt="image" src="https://github.com/user-attachments/assets/bfaed107-eead-452b-85e9-78525c28af70" />
<p align="center">Web preview retains translated text</p>

<img width="1919" height="979" alt="image" src="https://github.com/user-attachments/assets/cca0fa55-42b1-4130-85fb-ee61a0c4bde1" />
<p align="center">Translated text properly renders in DOCX export</p>