### PR TITLE
openai: drop hard dependency on azure provider

### DIFF
--- a/.github/workflows/ci-api.yaml
+++ b/.github/workflows/ci-api.yaml
@@ -54,12 +54,7 @@ jobs:
       - name: Run unit tests (before build)
         working-directory: shiksha-api/app-service
         env:
-          AZURE_OPENAI_API_KEY: dummy-key-for-testing
-          AZURE_OPENAI_ENDPOINT: https://dummy-endpoint.openai.azure.com/
-          AZURE_OPENAI_API_VERSION: 2025-03-01-preview
-          AZURE_OPENAI_DEPLOYMENT_NAME: dummy-deployment
-          AZURE_CHAT_DEPLOYMENT_NAME: dummy-chat-deployment
-          AZURE_OPENAI_EMBED_MODEL: text-embedding-ada-002
+          OPENAI_API_KEY: dummy-key-for-testing
           BING_API_KEY: dummy-bing-key
           BLOB_STORE_CONNECTION_STRING: DefaultEndpointsProtocol=https;AccountName=dummyaccount;AccountKey=dummykey;EndpointSuffix=core.windows.net
           QDRANT_URL: http://localhost:6333

--- a/.github/workflows/ci-api.yaml
+++ b/.github/workflows/ci-api.yaml
@@ -55,7 +55,6 @@ jobs:
         working-directory: shiksha-api/app-service
         env:
           OPENAI_API_KEY: dummy-key-for-testing
-          BING_API_KEY: dummy-bing-key
           BLOB_STORE_CONNECTION_STRING: DefaultEndpointsProtocol=https;AccountName=dummyaccount;AccountKey=dummykey;EndpointSuffix=core.windows.net
           QDRANT_URL: http://localhost:6333
           QDRANT_API_KEY: dummy-qdrant-key

--- a/components/rag-wrapper/README.md
+++ b/components/rag-wrapper/README.md
@@ -8,7 +8,7 @@ A Python library for Retrieval-Augmented Generation (RAG) operations using Llama
 - **Knowledge Graph Integration**: Extract entities and relationships for enhanced context understanding
 - **Metadata Filtering**: Filter results by document attributes across all backend types
 - **Chat Interface**: Conversational interactions with document collections and graph context
-- **Azure OpenAI Integration**: Built-in support for Azure OpenAI models for embeddings and completions
+- **OpenAI Integration**: Built-in support for OpenAI-compatible models for embeddings and completions
 - **Multiple Backends**: Support for in-memory, Azure AI Search, and property graph storage backends
 - **Flexible Retrieval**: Configurable sub-retrievers for custom retrieval strategies
 - **Graph Traversal**: Follow entity relationships with configurable path depth for richer context
@@ -24,21 +24,19 @@ pip install -e .
 ### In-Memory RAG
 
 ```python
-from llama_index.llms.azure_openai import AzureOpenAI
-from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
+from llama_index.llms.openai import OpenAI
+from llama_index.embeddings.openai import OpenAIEmbedding
 from rag_wrapper.rag_ops.in_mem_rag_ops import InMemRagOps
 
 # Initialize models
-embedding_model = AzureOpenAIEmbedding(
+embedding_model = OpenAIEmbedding(
     model="text-embedding-ada-002",
     api_key="your-api-key",
-    azure_endpoint="your-endpoint"
 )
 
-completion_model = AzureOpenAI(
-    model="gpt-35-turbo",
+completion_model = OpenAI(
+    model="gpt-4.1",
     api_key="your-api-key", 
-    azure_endpoint="your-endpoint"
 )
 
 # Create RAG instance
@@ -66,23 +64,21 @@ chat_response = await rag_ops.chat_with_index(
 ### Azure AI Search RAG
 
 ```python
-from llama_index.llms.azure_openai import AzureOpenAI
-from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
+from llama_index.llms.openai import OpenAI
+from llama_index.embeddings.openai import OpenAIEmbedding
 from rag_wrapper.rag_ops.azure_ai_search_rag_ops import AzureAISearchRagOps
 
 # Initialize models
-embedding_model = AzureOpenAIEmbedding(
+embedding_model = OpenAIEmbedding(
     model="text-embedding-ada-002",
     deployment_name="your-embedding-deployment",
     api_key="your-api-key",
-    azure_endpoint="your-endpoint"
 )
 
-completion_model = AzureOpenAI(
-    model="gpt-35-turbo",
+completion_model = OpenAI(
+    model="gpt-4.1",
     deployment_name="your-completion-deployment",
     api_key="your-api-key", 
-    azure_endpoint="your-endpoint"
 )
 
 # Create Azure AI Search RAG instance (using API key)
@@ -127,22 +123,20 @@ chat_response = await rag_ops.chat_with_index(
 ### Property Graph RAG
 
 ```python
-from llama_index.llms.azure_openai import AzureOpenAI
-from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
+from llama_index.llms.openai import OpenAI
+from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.core.indices.property_graph import SchemaLLMPathExtractor
 from rag_wrapper.rag_ops.in_mem_graph_rag_ops import InMemGraphRagOps
 
 # Initialize models
-embedding_model = AzureOpenAIEmbedding(
+embedding_model = OpenAIEmbedding(
     model="text-embedding-ada-002",
     api_key="your-api-key",
-    azure_endpoint="your-endpoint"
 )
 
-completion_model = AzureOpenAI(
-    model="gpt-35-turbo",
+completion_model = OpenAI(
+    model="gpt-4.1",
     api_key="your-api-key", 
-    azure_endpoint="your-endpoint"
 )
 
 # Create Property Graph RAG instance with custom knowledge extractors

--- a/components/rag-wrapper/tests/test_azure_ai_search_rag_ops.py
+++ b/components/rag-wrapper/tests/test_azure_ai_search_rag_ops.py
@@ -1,21 +1,13 @@
 """
 Azure AI Search RAG Operations Tests
 
-Tests require Azure AI Search and Azure OpenAI services with these environment variables:
+Tests require Azure AI Search and OpenAI services with these environment variables:
 
 Required:
 - AZURE_SEARCH_SERVICE_NAME: Search service name
 - AZURE_SEARCH_INDEX_NAME: Index name for testing
-- AZURE_OPENAI_API_KEY: OpenAI API key
-- AZURE_OPENAI_ENDPOINT: OpenAI endpoint
-- AZURE_OPENAI_EMBEDDING_MODEL: Embedding model (default: text-embedding-ada-002)
-- AZURE_OPENAI_EMBEDDING_DEPLOYMENT: Embedding deployment name
-- AZURE_OPENAI_COMPLETION_MODEL: Completion model (default: gpt-35-turbo)
-- AZURE_OPENAI_COMPLETION_DEPLOYMENT: Completion deployment name
-
-Optional:
-- AZURE_SEARCH_API_KEY: Search API key (if not using managed identity)
-- AZURE_OPENAI_API_VERSION: API version (default: 2025-03-01-preview)
+- OPENAI_EMBEDDING_MODEL: Embedding model (default: text-embedding-ada-002)
+- OPENAI_COMPLETION_MODEL: Completion model (default: gpt-4.1)
 
 Note: Creates real data in Azure services and may incur costs.
 """
@@ -23,18 +15,11 @@ Note: Creates real data in Azure services and may incur costs.
 import pytest
 import os
 import logging
-from typing import List
 from dotenv import load_dotenv
 
-from llama_index.llms.azure_openai import AzureOpenAI
-from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
-from llama_index.core.llms import ChatMessage
+from llama_index.llms.openai import OpenAI
+from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.core.node_parser import MarkdownNodeParser, SentenceSplitter
-from azure.search.documents.aio import SearchClient as AsyncSearchClient
-from llama_index.vector_stores.azureaisearch import AzureAISearchVectorStore
-
-from azure.core.credentials import AzureKeyCredential
-from azure.identity import DefaultAzureCredential
 
 from rag_wrapper.rag_ops.azure_ai_search_rag_ops import AzureAISearchRagOps
 
@@ -79,28 +64,12 @@ def metadata_fields_b():
 
 @pytest.fixture
 def embedding_llm():
-    """Initialize Azure OpenAI embedding model"""
-    return AzureOpenAIEmbedding(
-        model=os.getenv("AZURE_OPENAI_EMBEDDING_MODEL", "text-embedding-ada-002"),
-        deployment_name=os.getenv(
-            "AZURE_OPENAI_EMBEDDING_DEPLOYMENT", "text-embedding-ada-002"
-        ),
-        api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-        azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
-        api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2025-03-01-preview"),
-    )
+    return OpenAIEmbedding(model=os.getenv("OPENAI_EMBEDDING_MODEL", "text-embedding-ada-002"))
 
 
 @pytest.fixture
 def completion_llm():
-    """Initialize Azure OpenAI completion model"""
-    return AzureOpenAI(
-        model=os.getenv("AZURE_OPENAI_COMPLETION_MODEL", "gpt-35-turbo"),
-        deployment_name=os.getenv("AZURE_OPENAI_COMPLETION_DEPLOYMENT", "gpt-35-turbo"),
-        api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-        azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
-        api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2025-03-01-preview"),
-    )
+    return OpenAI(model=os.getenv("OPENAI_COMPLETION_MODEL", "gpt-4.1"))
 
 
 @pytest.fixture

--- a/components/rag-wrapper/tests/test_in_mem_rag_ops.py
+++ b/components/rag-wrapper/tests/test_in_mem_rag_ops.py
@@ -1,33 +1,21 @@
 """
 In-Memory RAG Operations Tests
 
-Tests require Azure OpenAI services with these environment variables:
+Tests require OpenAI services with these environment variables:
 
 Required:
-- AZURE_OPENAI_API_KEY: OpenAI API key
-- AZURE_OPENAI_ENDPOINT: OpenAI endpoint
-- AZURE_OPENAI_EMBEDDING_MODEL: Embedding model (default: text-embedding-ada-002)
-- AZURE_OPENAI_EMBEDDING_DEPLOYMENT: Embedding deployment name
-- AZURE_OPENAI_COMPLETION_MODEL: Completion model (default: gpt-35-turbo)
-- AZURE_OPENAI_COMPLETION_DEPLOYMENT: Completion deployment name
-
-Optional:
-- AZURE_OPENAI_API_VERSION: API version (default: 2025-03-01-preview)
+- OPENAI_EMBEDDING_MODEL: Embedding model (default: text-embedding-ada-002)
+- OPENAI_COMPLETION_MODEL: Completion model (default: gpt-4.1)
 """
 
 import pytest
-import tempfile
 import os
-import shutil
 import logging
-from unittest.mock import Mock, MagicMock
-from typing import List
 import uuid
 from dotenv import load_dotenv
 
-from llama_index.llms.azure_openai import AzureOpenAI
-from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
-from llama_index.core.llms import ChatMessage
+from llama_index.llms.openai import OpenAI
+from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.core.node_parser import MarkdownNodeParser, SentenceSplitter
 from rag_wrapper.rag_ops.in_mem_rag_ops import InMemRagOps
 
@@ -72,28 +60,12 @@ def metadata_fields_b():
 
 @pytest.fixture
 def embedding_llm():
-    """Initialize Azure OpenAI embedding model"""
-    return AzureOpenAIEmbedding(
-        model=os.getenv("AZURE_OPENAI_EMBEDDING_MODEL", "text-embedding-ada-002"),
-        deployment_name=os.getenv(
-            "AZURE_OPENAI_EMBEDDING_DEPLOYMENT", "text-embedding-ada-002"
-        ),
-        api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-        azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
-        api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2025-03-01-preview"),
-    )
+    return OpenAIEmbedding(model=os.getenv("OPENAI_EMBEDDING_MODEL", "text-embedding-ada-002"))
 
 
 @pytest.fixture
 def completion_llm():
-    """Initialize Azure OpenAI completion model"""
-    return AzureOpenAI(
-        model=os.getenv("AZURE_OPENAI_COMPLETION_MODEL", "gpt-35-turbo"),
-        deployment_name=os.getenv("AZURE_OPENAI_COMPLETION_DEPLOYMENT", "gpt-35-turbo"),
-        api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-        azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
-        api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2025-03-01-preview"),
-    )
+    return OpenAI(model=os.getenv("OPENAI_COMPLETION_MODEL", "gpt-4.1"))
 
 
 @pytest.fixture

--- a/components/rag-wrapper/tests/test_property_graph_rag_ops.py
+++ b/components/rag-wrapper/tests/test_property_graph_rag_ops.py
@@ -1,32 +1,22 @@
 """
 Property Graph RAG Operations Tests
 
-Tests require Azure OpenAI services with these environment variables:
+Tests require OpenAI services with these environment variables:
 
 Required:
-- AZURE_OPENAI_API_KEY: OpenAI API key
-- AZURE_OPENAI_ENDPOINT: OpenAI endpoint
-- AZURE_OPENAI_EMBEDDING_MODEL: Embedding model (default: text-embedding-ada-002)
-- AZURE_OPENAI_EMBEDDING_DEPLOYMENT: Embedding deployment name
-- AZURE_OPENAI_COMPLETION_MODEL: Completion model (default: gpt-35-turbo)
-- AZURE_OPENAI_COMPLETION_DEPLOYMENT: Completion deployment name
-
-Optional:
-- AZURE_OPENAI_API_VERSION: API version (default: 2025-03-01-preview)
+- OPENAI_EMBEDDING_MODEL: Embedding model (default: text-embedding-ada-002)
+- OPENAI_COMPLETION_MODEL: Completion model (default: gpt-4.1)
 """
 
 import pytest
-import tempfile
 import os
-import shutil
 import logging
-from unittest.mock import Mock, MagicMock
-from typing import List, Literal
+from typing import Literal
 import uuid
 from dotenv import load_dotenv
 
-from llama_index.llms.azure_openai import AzureOpenAI
-from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
+from llama_index.llms.openai import OpenAI
+from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.core.indices.property_graph import SchemaLLMPathExtractor
 from rag_wrapper.rag_ops.in_mem_graph_rag_ops import InMemGraphRagOps
 from llama_index.core.node_parser import MarkdownNodeParser, SentenceSplitter
@@ -84,41 +74,12 @@ def metadata_fields():
 
 @pytest.fixture
 def embedding_llm():
-    """Initialize Azure OpenAI embedding model"""
-    return AzureOpenAIEmbedding(
-        model=os.getenv("AZURE_OPENAI_EMBEDDING_MODEL", "text-embedding-ada-002"),
-        deployment_name=os.getenv(
-            "AZURE_OPENAI_EMBEDDING_DEPLOYMENT", "text-embedding-ada-002"
-        ),
-        api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-        azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
-        api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2025-03-01-preview"),
-    )
+    return OpenAIEmbedding(model=os.getenv("OPENAI_EMBEDDING_MODEL", "text-embedding-ada-002"))
 
 
 @pytest.fixture
 def completion_llm():
-    """Initialize Azure OpenAI completion model and log environment values"""
-    model = os.getenv("AZURE_OPENAI_COMPLETION_MODEL", "gpt-35-turbo")
-    deployment_name = os.getenv("AZURE_OPENAI_COMPLETION_DEPLOYMENT", "gpt-35-turbo")
-    api_key = os.getenv("AZURE_OPENAI_API_KEY")
-    azure_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
-    api_version = os.getenv("AZURE_OPENAI_API_VERSION", "2025-03-01-preview")
-
-    logger.info(
-        f"\nAzure OpenAI Completion Model Env: "
-        f"\nmodel={model}, deployment_name={deployment_name}, "
-        f"\napi_key={'set' if api_key else 'not set'}, "
-        f"\nazure_endpoint={azure_endpoint}, \napi_version={api_version}"
-    )
-
-    return AzureOpenAI(
-        model=model,
-        deployment_name=deployment_name,
-        api_key=api_key,
-        azure_endpoint=azure_endpoint,
-        api_version=api_version,
-    )
+    return OpenAI(model=os.getenv("OPENAI_COMPLETION_MODEL", "gpt-4.1"))
 
 
 @pytest.fixture
@@ -251,7 +212,7 @@ The modern AI renaissance has been shaped by three visionary scientists, collect
     ]
 
 
-# Integration tests with real Azure OpenAI LLMs
+# Integration tests with real OpenAI LLMs
 @pytest.mark.asyncio
 async def test_create_index_with_metadata(
     graph_rag_ops_instance: InMemGraphRagOps,

--- a/components/rag-wrapper/tests/test_qdrant_rag_ops.py
+++ b/components/rag-wrapper/tests/test_qdrant_rag_ops.py
@@ -16,12 +16,10 @@ Note: Creates real data in Qdrant and may incur costs if using paid OpenAI endpo
 import pytest
 import os
 import logging
-from typing import List
 from dotenv import load_dotenv
 
-from llama_index.llms.azure_openai import AzureOpenAI
-from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
-from llama_index.core.llms import ChatMessage
+from llama_index.llms.openai import OpenAI
+from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.core.node_parser import MarkdownNodeParser, SentenceSplitter
 from rag_wrapper import QdrantRagOps
 
@@ -51,28 +49,12 @@ def metadata_fields_b():
 
 @pytest.fixture
 def embedding_llm():
-    """Initialize Azure OpenAI embedding model"""
-    return AzureOpenAIEmbedding(
-        model=os.getenv("AZURE_OPENAI_EMBEDDING_MODEL", "text-embedding-ada-002"),
-        deployment_name=os.getenv(
-            "AZURE_OPENAI_EMBEDDING_DEPLOYMENT", "text-embedding-ada-002"
-        ),
-        api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-        azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
-        api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2025-03-01-preview"),
-    )
+    return OpenAIEmbedding(model=os.getenv("OPENAI_EMBEDDING_MODEL", "text-embedding-ada-002"))
 
 
 @pytest.fixture
 def completion_llm():
-    """Initialize Azure OpenAI completion model"""
-    return AzureOpenAI(
-        model=os.getenv("AZURE_OPENAI_COMPLETION_MODEL", "gpt-35-turbo"),
-        deployment_name=os.getenv("AZURE_OPENAI_COMPLETION_DEPLOYMENT", "gpt-35-turbo"),
-        api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-        azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
-        api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2025-03-01-preview"),
-    )
+    return OpenAI(model=os.getenv("OPENAI_COMPLETION_MODEL", "gpt-4.1"))
 
 @pytest.fixture
 def qdrant_config():

--- a/components/translation/data_collection/cleanup_sentence_pairs.py
+++ b/components/translation/data_collection/cleanup_sentence_pairs.py
@@ -5,30 +5,19 @@ import json
 from tqdm.auto import tqdm
 from dotenv import load_dotenv
 
-from openai import AzureOpenAI
-from azure.identity import AzureCliCredential, get_bearer_token_provider
+from openai import OpenAI
 
 load_dotenv()
 
-AZURE_ENDPOINT = os.getenv('AZURE_ENDPOINT')
 GPT4_MODEL_NAME = os.getenv('GPT4_MODEL_NAME')
 GPT4_MODEL_ENGINE = os.getenv('GPT4_MODEL_ENGINE')
 CONTEXT_LENGTH = 128000
 MAX_NEW_TOKENS = 4096
 
 kannad_numerals = set(["೦", "೧", "೨", "೩", "೪", "೫", "೬", "೭", "೮", "೯"])
-token_provider = get_bearer_token_provider(AzureCliCredential(), "https://cognitiveservices.azure.com/.default")
 
 
-def load_model():
-    llm_ = AzureOpenAI(
-        azure_ad_token_provider=token_provider,
-        api_version="2023-03-15-preview",
-        azure_endpoint=AZURE_ENDPOINT,
-    )
-    return llm_
-
-def ask_model(model: AzureOpenAI, query: dict):
+def ask_model(model: OpenAI, query: dict):
     response = model.chat.completions.create(
         model=GPT4_MODEL_ENGINE,
         messages=query,
@@ -55,9 +44,7 @@ def ask_query_on_text(query, content):
         ],
     }
 
-    model = load_model()
-
-    return ask_model(model, sample_msg["messages"])
+    return ask_model(OpenAI(), sample_msg["messages"])
 
 def number_present(sentence):
     return any((char.isdigit() or (char in kannad_numerals)) for char in sentence)

--- a/components/translation/data_collection/cleanup_sentence_pairs.py
+++ b/components/translation/data_collection/cleanup_sentence_pairs.py
@@ -9,6 +9,8 @@ from openai import OpenAI
 
 load_dotenv()
 
+_client = OpenAI()
+
 GPT4_MODEL_NAME = os.getenv('GPT4_MODEL_NAME')
 GPT4_MODEL_ENGINE = os.getenv('GPT4_MODEL_ENGINE')
 CONTEXT_LENGTH = 128000
@@ -44,7 +46,7 @@ def ask_query_on_text(query, content):
         ],
     }
 
-    return ask_model(OpenAI(), sample_msg["messages"])
+    return ask_model(_client, sample_msg["messages"])
 
 def number_present(sentence):
     return any((char.isdigit() or (char in kannad_numerals)) for char in sentence)

--- a/components/translation/data_collection/extraFilter-maths.py
+++ b/components/translation/data_collection/extraFilter-maths.py
@@ -1,20 +1,15 @@
 import os
 import re
 import json
-import ast
 from glob import glob
-from tqdm.auto import tqdm
 from dotenv import load_dotenv
 
-from openai import AzureOpenAI
-from azure.identity import AzureCliCredential, get_bearer_token_provider
+from openai import OpenAI
 
 from transformers import AutoTokenizer
 
-from cleanup_sentence_pairs import post_proc
 load_dotenv()
 
-AZURE_ENDPOINT = os.getenv('AZURE_ENDPOINT')
 GPT4_MODEL_NAME = os.getenv('GPT4_MODEL_NAME')
 GPT4_MODEL_ENGINE = os.getenv('GPT4_MODEL_ENGINE')
 CONTEXT_LENGTH = 128000
@@ -22,8 +17,6 @@ MAX_NEW_TOKENS = 4096
 
 TOKENIZER = AutoTokenizer.from_pretrained("sarvamai/sarvam-2b-v0.5")
 TOKENIZER.chat_template = "{% if messages[0]['role'] == 'system' %}{% set loop_messages = messages[1:] %}{% set system_message = messages[0]['content'] %}{% else %}{% set loop_messages = messages %}{% set system_message = false %}{% endif %}{% for message in loop_messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% if loop.index0 == 0 and system_message != false %}{% set content = '<<SYS>>\\n' + system_message + '\\n<</SYS>>\\n\\n' + message['content'] %}{% else %}{% set content = message['content'] %}{% endif %}{% if message['role'] == 'user' %}{{ bos_token + '[INST] ' + content.strip() + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ ' '  + content.strip() + ' ' + eos_token }}{% endif %}{% endfor %}"
-
-token_provider = get_bearer_token_provider(AzureCliCredential(), "https://cognitiveservices.azure.com/.default")
 
 kannada_to_roman = {
     '೦': '0',
@@ -38,15 +31,7 @@ kannada_to_roman = {
     '೯': '9'
 }
 
-def load_model():
-    llm_ = AzureOpenAI(
-        azure_ad_token_provider=token_provider,
-        api_version="2023-03-15-preview",
-        azure_endpoint=AZURE_ENDPOINT,
-    )
-    return llm_
-
-def ask_model(model: AzureOpenAI, query: dict):
+def ask_model(model: OpenAI, query: dict):
     response = model.chat.completions.create(
         model=GPT4_MODEL_ENGINE,
         messages=query,
@@ -73,8 +58,7 @@ def ask_query_on_text(query, content):
         ],
     }
 
-    model = load_model()
-    return ask_model(model, sample_msg["messages"])
+    return ask_model(OpenAI(), sample_msg["messages"])
 
 def club_sentences(words_to_sent):
     inverse_dict = {}

--- a/components/translation/data_collection/extraFilter-maths.py
+++ b/components/translation/data_collection/extraFilter-maths.py
@@ -10,6 +10,8 @@ from transformers import AutoTokenizer
 
 load_dotenv()
 
+_client = OpenAI()
+
 GPT4_MODEL_NAME = os.getenv('GPT4_MODEL_NAME')
 GPT4_MODEL_ENGINE = os.getenv('GPT4_MODEL_ENGINE')
 CONTEXT_LENGTH = 128000
@@ -58,7 +60,7 @@ def ask_query_on_text(query, content):
         ],
     }
 
-    return ask_model(OpenAI(), sample_msg["messages"])
+    return ask_model(_client, sample_msg["messages"])
 
 def club_sentences(words_to_sent):
     inverse_dict = {}

--- a/components/translation/data_collection/extract_sentence_pairs.py
+++ b/components/translation/data_collection/extract_sentence_pairs.py
@@ -5,30 +5,18 @@ from glob import glob
 from tqdm.auto import tqdm
 from dotenv import load_dotenv
 
-from openai import AzureOpenAI
-from azure.identity import AzureCliCredential, get_bearer_token_provider
+from openai import OpenAI
 
 from cleanup_sentence_pairs import post_proc
 load_dotenv()
 
-AZURE_ENDPOINT = os.getenv('AZURE_ENDPOINT')
 GPT4_MODEL_NAME = os.getenv('GPT4_MODEL_NAME')
 GPT4_MODEL_ENGINE = os.getenv('GPT4_MODEL_ENGINE')
 CONTEXT_LENGTH = 128000
 MAX_NEW_TOKENS = 4096
 
 
-token_provider = get_bearer_token_provider(AzureCliCredential(), "https://cognitiveservices.azure.com/.default")
-
-def load_model():
-    llm_ = AzureOpenAI(
-        azure_ad_token_provider=token_provider,
-        api_version="2023-03-15-preview",
-        azure_endpoint=AZURE_ENDPOINT,
-    )
-    return llm_
-
-def ask_model(model: AzureOpenAI, query: dict):
+def ask_model(model: OpenAI, query: dict):
     response = model.chat.completions.create(
         model=GPT4_MODEL_ENGINE,
         messages=query,
@@ -55,8 +43,7 @@ def ask_query_on_text(query, content):
         ],
     }
 
-    model = load_model()
-    return ask_model(model, sample_msg["messages"])
+    return ask_model(OpenAI(), sample_msg["messages"])
 
 def club_sentences(words_to_sent):
     inverse_dict = {}

--- a/components/translation/data_collection/extract_sentence_pairs.py
+++ b/components/translation/data_collection/extract_sentence_pairs.py
@@ -10,6 +10,8 @@ from openai import OpenAI
 from cleanup_sentence_pairs import post_proc
 load_dotenv()
 
+_client = OpenAI()
+
 GPT4_MODEL_NAME = os.getenv('GPT4_MODEL_NAME')
 GPT4_MODEL_ENGINE = os.getenv('GPT4_MODEL_ENGINE')
 CONTEXT_LENGTH = 128000
@@ -43,7 +45,7 @@ def ask_query_on_text(query, content):
         ],
     }
 
-    return ask_model(OpenAI(), sample_msg["messages"])
+    return ask_model(_client, sample_msg["messages"])
 
 def club_sentences(words_to_sent):
     inverse_dict = {}

--- a/components/translation/data_collection/gpt4v.py
+++ b/components/translation/data_collection/gpt4v.py
@@ -1,12 +1,8 @@
 import base64
 from mimetypes import guess_type
-from openai import AzureOpenAI
-from azure.identity import AzureCliCredential, get_bearer_token_provider
+from openai import OpenAI
 import json
 import ast
-
-token_provider = get_bearer_token_provider(AzureCliCredential(), "https://cognitiveservices.azure.com/.default")
-
 
 
 # Function to encode a local image into data URL 
@@ -29,18 +25,14 @@ def get_toc(image_path):
     # image_path = '/home/t-narora/translation/scraped_books/KSEEB_kan/english/8/science_2/images/3.jpg'
     data_url = local_image_to_data_url(image_path)
 
-    client = AzureOpenAI(
-        azure_ad_token_provider=token_provider,
-        api_version="2025-03-01-preview",
-        azure_endpoint="https://vellm-openai3.openai.azure.com/",
-    )
+    client = OpenAI()
 
     flag = True
     tries = 0
     while flag:
         
         response = client.chat.completions.create(
-            model="GPT-4.1",
+            model="gpt-4.1",
             messages=[
                 { "role": "system", "content": "You are a helpful assistant. You give output in correct json format." },
                 { "role": "user", "content": [  

--- a/shiksha-api/app-service/.env.example
+++ b/shiksha-api/app-service/.env.example
@@ -6,12 +6,20 @@ APP_NAME="Shiksha Copilot Fast API"
 HOST=0.0.0.0
 PORT=8000
 
-# Azure OpenAI Configuration
-AZURE_OPENAI_API_KEY=your_azure_openai_api_key_here
-AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
-AZURE_OPENAI_API_VERSION=2025-03-01-preview
-AZURE_OPENAI_DEPLOYMENT_NAME=your_deployment_name_here
-AZURE_OPENAI_EMBED_MODEL=your_embedding_model_here
+# OpenAI Configuration
+OPENAI_API_KEY=your_azure_openai_api_key_here
+
+# Custom endpoint - required for non-OpenAI providers (Gemini, Grok, local proxy).
+# NOTE: two env vars must point to the same value.
+# The OpenAI SDK reads OPENAI_BASE_URL, llama-index (used for RAG) reads OPENAI_API_BASE.
+OPENAI_BASE_URL=
+OPENAI_API_BASE=
+
+# Optional model overrides
+EMBED_MODEL=text-embedding-ada-002
+GENERAL_CHAT_MODEL=gpt-4.1
+LESSON_CHAT_MODEL=gpt-4.1
+QUESTION_PAPER_MODEL=gpt-4.1
 
 # Bing Search Configuration
 BING_API_KEY=your_bing_search_api_key_here

--- a/shiksha-api/app-service/.env.example
+++ b/shiksha-api/app-service/.env.example
@@ -7,7 +7,7 @@ HOST=0.0.0.0
 PORT=8000
 
 # OpenAI Configuration
-OPENAI_API_KEY=your_azure_openai_api_key_here
+OPENAI_API_KEY=your_openai_api_key_here
 
 # Custom endpoint - required for non-OpenAI providers (Gemini, Grok, local proxy).
 # NOTE: two env vars must point to the same value.

--- a/shiksha-api/app-service/.env.example
+++ b/shiksha-api/app-service/.env.example
@@ -21,9 +21,6 @@ GENERAL_CHAT_MODEL=gpt-4.1
 LESSON_CHAT_MODEL=gpt-4.1
 QUESTION_PAPER_MODEL=gpt-4.1
 
-# Bing Search Configuration
-BING_API_KEY=your_bing_search_api_key_here
-
 # Blob Storage Configuration
 BLOB_STORE_CONNECTION_STRING=your_blob_storage_connection_string_here
 

--- a/shiksha-api/app-service/app/config.py
+++ b/shiksha-api/app-service/app/config.py
@@ -36,6 +36,7 @@ class Settings(BaseSettings):
     langfuse_host: Optional[str] = Field(default=None, alias="LANGFUSE_HOST")
 
     # LLM Configuration
+    openai_api_key: str = Field(min_length=1)
     embed_model: str = "text-embedding-ada-002"
     general_chat_model: str = "gpt-4.1"
     lesson_chat_model: str = "gpt-4.1"

--- a/shiksha-api/app-service/app/config.py
+++ b/shiksha-api/app-service/app/config.py
@@ -35,17 +35,11 @@ class Settings(BaseSettings):
     langfuse_public_key: Optional[str] = Field(default=None, alias="LANGFUSE_PUBLIC_KEY")
     langfuse_host: Optional[str] = Field(default=None, alias="LANGFUSE_HOST")
 
-    # Azure OpenAI Configuration
-    azure_openai_api_key: Optional[str] = None
-    azure_openai_endpoint: Optional[str] = None
-    azure_openai_api_version: Optional[str] = None
-    azure_openai_deployment_name: Optional[str] = None
-    azure_openai_embed_model: Optional[str] = None
-    azure_chat_deployment_name : Optional[str] = None
-
-    # Azure AI Project Configuration
-    azure_project_endpoint: Optional[str] = None
-    azure_bing_grounding_connection_id: Optional[str] = None
+    # LLM Configuration
+    embed_model: str = "text-embedding-ada-002"
+    general_chat_model: str = "gpt-4.1"
+    lesson_chat_model: str = "gpt-4.1"
+    question_paper_model: str = "gpt-4.1"
 
     # Blob Store Configuration
     blob_store_connection_string: Optional[str] = None

--- a/shiksha-api/app-service/app/services/general_chat_service.py
+++ b/shiksha-api/app-service/app/services/general_chat_service.py
@@ -1,12 +1,10 @@
 from typing import List
 from pathlib import Path
 import logging
-import traceback
 
-from langfuse.openai import AsyncAzureOpenAI
+from langfuse.openai import AsyncOpenAI
 from langfuse import observe, get_client
 import json
-import asyncio
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
 from openai.types.responses.response import Response
 from openai.types.responses.response_output_text import AnnotationURLCitation
@@ -20,32 +18,12 @@ logger = logging.getLogger(__name__)
 
 
 class GeneralChatService:
-    """Service for handling chat interactions using Azure OpenAI client."""
+    """Service for handling chat interactions using OpenAI client."""
 
     def __init__(self):
-        # Initialize prompt template with the chat prompts file
-        prompts_file_path = (
-            Path(__file__).parent.parent.parent / "prompts" / "chat_prompts.yaml"
-        )
+        prompts_file_path = Path(__file__).parent.parent.parent / "prompts" / "chat_prompts.yaml"
         self.prompt_template = PromptTemplate(str(prompts_file_path))
-
-        # Check configuration
-        if not settings.azure_openai_api_key:
-            raise ValueError("AZURE_OPENAI_API_KEY environment variable is required")
-        if not settings.azure_openai_endpoint:
-            raise ValueError("AZURE_OPENAI_ENDPOINT environment variable is required")
-        if not settings.azure_openai_api_version:
-            raise ValueError("AZURE_OPENAI_API_VERSION environment variable is required")
-        if not settings.azure_openai_deployment_name:
-            raise ValueError("AZURE_OPENAI_DEPLOYMENT_NAME environment variable is required")
-        if not settings.azure_chat_deployment_name:
-            raise ValueError("AZURE_CHAT_DEPLOYMENT_NAME environment variable is required")
-
-        self.client = AsyncAzureOpenAI(
-                api_key=settings.azure_openai_api_key,
-                api_version=settings.azure_openai_api_version,
-                azure_endpoint=settings.azure_openai_endpoint,
-            )
+        self.client = AsyncOpenAI()
 
 
     @validate_call
@@ -76,7 +54,7 @@ class GeneralChatService:
 
             # Responses API with web search
             stream = await self.client.responses.create(
-                model=settings.azure_chat_deployment_name,
+                model=settings.general_chat_model,
                 input=formatted_messages,
                 tools=[{"type": "web_search"}],
                 stream=True,
@@ -106,7 +84,7 @@ class GeneralChatService:
                 }) + "\n"
 
         except Exception as e:
-            logger.error(f"Error in Azure OpenAI chat: {e}", exc_info=True)
+            logger.error(f"Error in OpenAI chat: {e}", exc_info=True)
             yield json.dumps({
                 "type": "error",
                 "message": str(e)
@@ -114,7 +92,7 @@ class GeneralChatService:
 
     def _extract_url_citations(self, response: Response) -> list:
         """
-        Extract URL citations from Azure OpenAI Responses API output annotations.
+        Extract URL citations from OpenAI Responses API output annotations.
 
         The Responses API returns output items that may contain 'url_citation'
         annotations within message content blocks.

--- a/shiksha-api/app-service/app/services/lesson_chat_service.py
+++ b/shiksha-api/app-service/app/services/lesson_chat_service.py
@@ -1,12 +1,14 @@
 from pathlib import Path
 import logging
 import re
+from app.config import settings
 from app.models.chat import LessonChatRequest
 from app.services.rag_adapter_cache import RagAdapterCache
 from app.utils.prompt_template import PromptTemplate
-from app.utils.utils import new_rag_embed, new_rag_llm
 from llama_index.core.llms import ChatMessage
 from langfuse import observe, get_client
+from llama_index.embeddings.openai import OpenAIEmbedding
+from llama_index.llms.openai import OpenAIResponses
 
 logger = logging.getLogger(__name__)
 
@@ -17,13 +19,11 @@ class LessonChatService:
     def __init__(self):
         """Initialize the lesson chat service with LLM models and blob store."""
         # Initialize prompt template with the chat prompts file
-        prompts_file_path = (
-            Path(__file__).parent.parent.parent / "prompts" / "chat_prompts.yaml"
-        )
+        prompts_file_path = Path(__file__).parent.parent.parent / "prompts" / "chat_prompts.yaml"
         self._prompt_template = PromptTemplate(str(prompts_file_path))
 
-        self._rag_llm = new_rag_llm()
-        self._rag_embed = new_rag_embed()
+        self._rag_llm = OpenAIResponses(model=settings.lesson_chat_model)
+        self._rag_embed = OpenAIEmbedding(model=settings.embed_model)
         self._rags = RagAdapterCache(RagAdapterCache.from_factory)
 
     @observe(name="Shiksha-QA")

--- a/shiksha-api/app-service/app/services/question_paper_service.py
+++ b/shiksha-api/app-service/app/services/question_paper_service.py
@@ -49,6 +49,9 @@ class QuestionPaperService:
 
     def __init__(self):
         self.client = AsyncOpenAI()
+        self._rag_llm = OpenAIResponses(model=settings.question_paper_model)
+        self._rag_embed = OpenAIEmbedding(model=settings.embed_model)
+        self._rags = RagAdapterCache(RagAdapterCache.from_factory)
         self.prompt_dir = Path(__file__).parent.parent.parent / "prompts"
         self.prompts = self._load_prompts()
         self.max_questions_per_slot = 20
@@ -56,9 +59,6 @@ class QuestionPaperService:
 
 
     async def __aenter__(self):
-        self._rag_llm = OpenAIResponses(model=settings.question_paper_model)
-        self._rag_embed = OpenAIEmbedding(model=settings.embed_model)
-        self._rags = RagAdapterCache(RagAdapterCache.from_factory)
         return self
 
 

--- a/shiksha-api/app-service/app/services/question_paper_service.py
+++ b/shiksha-api/app-service/app/services/question_paper_service.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 import json
 from app.services.rag_adapter_cache import RagAdapterCache
-from app.utils.utils import local_unique_id, new_rag_embed, new_rag_llm
+from app.utils.utils import local_unique_id
 from pydantic import Field, create_model
 import yaml
 import asyncio
@@ -10,12 +10,13 @@ from typing import List, Dict, Any, Optional
 import logging
 
 # 1. Official OpenAI SDK (For Direct Generation & Chat)
-from openai.types import ResponsesModel
 from langfuse import observe, get_client
-from langfuse.openai import AsyncAzureOpenAI  # noqa: F401 — enables langfuse auto-tracing; test asserts this import
+from langfuse.openai import AsyncOpenAI
 
 # 2. LlamaIndex Imports (Strictly for RAG Adapter Compatibility)
 from llama_index.core.llms import ChatMessage
+from llama_index.embeddings.openai import OpenAIEmbedding
+from llama_index.llms.openai import OpenAIResponses
 
 # 3. Import only the Factory and Base Adapter
 from app.services.rag_adapters import BaseRagAdapter
@@ -44,21 +45,10 @@ GeneratedSlotQuestion = tuple[SlotId, GeneratedQuestionItem]
 
 
 class QuestionPaperService:
-    """Service for handling question paper generation using Azure OpenAI."""
+    """Service for handling question paper generation using OpenAI."""
 
-    chat_deployment: ResponsesModel
     def __init__(self):
-        self.client = AsyncAzureOpenAI(
-            api_key=settings.azure_openai_api_key,
-            api_version=settings.azure_openai_api_version,
-            azure_endpoint=settings.azure_openai_endpoint,
-        )
-        if settings.azure_openai_deployment_name is None:
-            raise RuntimeError("OpenAI deployment model must be specified")
-        self.chat_deployment = settings.azure_openai_deployment_name
-        self.embedding_deployment = settings.azure_openai_embed_model
-
-        # Load YAML prompts
+        self.client = AsyncOpenAI()
         self.prompt_dir = Path(__file__).parent.parent.parent / "prompts"
         self.prompts = self._load_prompts()
         self.max_questions_per_slot = 20
@@ -66,8 +56,8 @@ class QuestionPaperService:
 
 
     async def __aenter__(self):
-        self._rag_llm = new_rag_llm()
-        self._rag_embed = new_rag_embed()
+        self._rag_llm = OpenAIResponses(model=settings.question_paper_model)
+        self._rag_embed = OpenAIEmbedding(model=settings.embed_model)
         self._rags = RagAdapterCache(RagAdapterCache.from_factory)
         return self
 
@@ -186,7 +176,7 @@ class QuestionPaperService:
     async def _generate_questions_batch(self, system_prompt: str, request: QuestionBankPartsGenerationRequest, existing_questions: list[str], record: _LearningRecord, slot: list[GenerationSlot], rag_adapter: Optional[BaseRagAdapter]) -> list[GeneratedSlotQuestion]:
         """
         Generate questions for a batch of slots.
-        Uses RAG Adapter if available, otherwise uses direct Azure OpenAI call.
+        Uses RAG Adapter if available, otherwise uses direct OpenAI call.
         """
 
         # Format learning outcomes for this specific unit
@@ -221,7 +211,7 @@ class QuestionPaperService:
                 "unit_name": record.title,
                 "question_types": [t.type.value for _, t, _ in slot],
                 "slot_count": len(slot),
-                "model": self.chat_deployment,
+                "model": settings.question_paper_model,
                 "rag_enabled": rag_adapter is not None,
                 "index_path": record.index_path,
             },
@@ -232,7 +222,7 @@ class QuestionPaperService:
                 # No Index -> Direct Generation (Zero-Shot)
                 logger.info("Using Direct LLM Generation (No RAG).")
                 response = await self.client.responses.parse(
-                    model=self.chat_deployment,
+                    model=settings.question_paper_model,
                     instructions=system_prompt,
                     input=user_message,
                     text_format=response_format,
@@ -356,7 +346,7 @@ class QuestionPaperService:
                 "learning_outcomes": all_los,
                 "question_types": [t.type.value for t in request.template],
                 "total_marks": request.total_marks,
-                "model": getattr(self, "chat_deployment", None),
+                "model": settings.question_paper_model,
             },
         )
 

--- a/shiksha-api/app-service/app/utils/utils.py
+++ b/shiksha-api/app-service/app/utils/utils.py
@@ -1,31 +1,5 @@
 import hashlib
 
-from app.config import settings
-from llama_index.llms.openai import OpenAIResponses
-from llama_index.llms.azure_openai import AzureOpenAIResponses
-from llama_index.embeddings.openai import OpenAIEmbedding
-from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
-
-
-def new_rag_llm() -> OpenAIResponses:
-    return AzureOpenAIResponses(
-        model=settings.azure_openai_deployment_name,
-        deployment_name=settings.azure_openai_deployment_name,
-        api_key=settings.azure_openai_api_key,
-        api_version=settings.azure_openai_api_version,
-        azure_endpoint=settings.azure_openai_endpoint,
-    )
-
-
-def new_rag_embed() -> OpenAIEmbedding:
-    return AzureOpenAIEmbedding(
-        model=settings.azure_openai_embed_model,
-        deployment_name=settings.azure_openai_embed_model,
-        api_key=settings.azure_openai_api_key,
-        azure_endpoint=settings.azure_openai_endpoint,
-        api_version=settings.azure_openai_api_version,
-    )
-
 
 def local_unique_id(counter: int) -> str:
     # key really does not matter here, wee aren't aiming for crypto-secure but rather 'random-enough'. determinism

--- a/shiksha-api/app-service/poetry.lock
+++ b/shiksha-api/app-service/poetry.lock
@@ -1447,7 +1447,6 @@ files = [
     {file = "fastavro-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bc44ba6289fb1f5ee318335958dde6ad6d742dcb4bb8930de843e9024c64b68c"},
     {file = "fastavro-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:a475418f71c5aed69899813ecccf392429c08c3a63df3030129db71760b0db8f"},
     {file = "fastavro-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:daec9f9655a1d4636613c47d6d3343f6e039150d66cdce62543e20ca36612a8a"},
-    {file = "fastavro-1.12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:57594b72cf663bbd0f3ad8a319a999fc3d7c71065a6799b2c1d1a6a137894c5b"},
     {file = "fastavro-1.12.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74412132bbfb153cbf704517f2c89f7d3e170feb681b13bceace690f66f8d5fa"},
     {file = "fastavro-1.12.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e367a84c9133018e0a3bc822abe78d7f1f9a6092991a0ec409468cf4ef260282"},
     {file = "fastavro-1.12.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:044fafca0853e9ae14009de7763ac9e8e8f8b96f8a4e90bd58b695443266a370"},
@@ -3169,7 +3168,6 @@ files = [
     {file = "lxml-6.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37a58976370f36d9329d118ad0b953c5aeb9119ac9c6a4e258942a225d0573a1"},
     {file = "lxml-6.1.1-cp310-cp310-win32.whl", hash = "sha256:cea3f4c1af79af13cdb2da0c028111d8f8522d4f22a000c82385535f24e5cf3a"},
     {file = "lxml-6.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:3abf332af33a74288675d936fe861fd4344da0dd6622193fbc4f2bfbb35536b5"},
-    {file = "lxml-6.1.1-cp310-cp310-win_arm64.whl", hash = "sha256:8dadbe5b217ff35b6a8d16610dd710219b59b76d13f0e3f0d9f36786206e4485"},
     {file = "lxml-6.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:53b7d2b7a10b1c35c0a5e21e9224accf60c1bbfba523990732e521b2b73adef2"},
     {file = "lxml-6.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ff3f333630ab480244a1bff72043e511a91eb22e7595dead8653ee5612dd8f3d"},
     {file = "lxml-6.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a4bbea04c97f6d78a48e3fbc1cb9116d2780b1b39e03a23f6eb9b603fd61f510"},
@@ -3185,7 +3183,6 @@ files = [
     {file = "lxml-6.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80c2dfadb855da477cf73373ad29a333535dedb9b12bad02c9814c8e2b43bf08"},
     {file = "lxml-6.1.1-cp311-cp311-win32.whl", hash = "sha256:30a89d3ac8faec007453fb541f3f46807eeec88edd5826f6e3fe001752a2c621"},
     {file = "lxml-6.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:abbefa31eee84842140f67acef1c828e28bba8bbf0c3bc6e5492a9af88152c28"},
-    {file = "lxml-6.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:dcb292aa7fe485ceff7af4f92e46c5af397daec5dff64871a528f0fc47a3cc5b"},
     {file = "lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7"},
     {file = "lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1"},
     {file = "lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc"},
@@ -3203,7 +3200,6 @@ files = [
     {file = "lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a"},
     {file = "lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a"},
     {file = "lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77"},
-    {file = "lxml-6.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:6540377fbd53fe1b629172288c464fb18db11ce1fa7dc15891da10aa9dcc3e7f"},
     {file = "lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736"},
     {file = "lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9"},
     {file = "lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354"},
@@ -3221,7 +3217,6 @@ files = [
     {file = "lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947"},
     {file = "lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca"},
     {file = "lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660"},
-    {file = "lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc"},
     {file = "lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0"},
     {file = "lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840"},
     {file = "lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14"},
@@ -3239,7 +3234,6 @@ files = [
     {file = "lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb"},
     {file = "lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603"},
     {file = "lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137"},
-    {file = "lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf"},
     {file = "lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee"},
     {file = "lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c"},
     {file = "lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef"},
@@ -3257,7 +3251,6 @@ files = [
     {file = "lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e"},
     {file = "lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1"},
     {file = "lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e"},
-    {file = "lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c"},
     {file = "lxml-6.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6689e828a94eee4f139408c337bb198e014724bb8a8c26d3cfac49d119ed69a6"},
     {file = "lxml-6.1.1-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bdebcc8a75d38c7598dfb2c9ed852d7a9eb4a10d6e2d0764b919b802bf32ac88"},
     {file = "lxml-6.1.1-cp38-cp38-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8be8ad51249698103d24b0571df35a10990fbe93dd043b6c024172189485f5e3"},
@@ -3280,7 +3273,6 @@ files = [
     {file = "lxml-6.1.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c9a4b821dc7055bf9e05ff5719e18ec501f75c0f0bbfabd573b277559780833d"},
     {file = "lxml-6.1.1-cp39-cp39-win32.whl", hash = "sha256:639f6c857d91d9be29bd7502348d6736dab168b54b5158cd899abf11684dc186"},
     {file = "lxml-6.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:34c2d737beabfe35baada43941ed519251e9a12e779031496bcd5d539fcfd730"},
-    {file = "lxml-6.1.1-cp39-cp39-win_arm64.whl", hash = "sha256:07a4a68e286ee7a1ed7dfb8af83e615757c0ccfe9f18c6b4ea6771388d9ba8c9"},
     {file = "lxml-6.1.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:31033dc34636ea6b7d5cc11b1ddbda78a14de858ba9d3e1ed4b69a3085bc521e"},
     {file = "lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3893c14c4b6ac5b2d54ba8cf03e99fe5104e592de491f19bd6b82756c09f8004"},
     {file = "lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c07da4cebf6889f03ebac8d238f62318e29f495de0aa18a51ea14e61ae907e2e"},
@@ -4017,7 +4009,6 @@ files = [
     {file = "onnxruntime-1.26.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11a8df4dcfe9ad5ff0bd71a7571dbed019fabc7594676c89fe8b86ea029c246f"},
     {file = "onnxruntime-1.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:e6456718125fd777c673f3b78d4a9ab58d6adea641e9afae85ee6444f0e0e9a9"},
     {file = "onnxruntime-1.26.0-cp311-cp311-win_arm64.whl", hash = "sha256:cd920e45b730e4a87833e2910d8ca375aaca9da6ccc09e24bce463b3356d637f"},
-    {file = "onnxruntime-1.26.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:05b028781b322ad74b57ce5b50aa5280bb1fe96ceec334628ade681e0b24c1ac"},
     {file = "onnxruntime-1.26.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:91f2bb870a4b9224eba0a6728c1fa7a9e552b8e59e1083c51fbbc3d013f2b5c0"},
     {file = "onnxruntime-1.26.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b6dd70599005bd1bf29779f04a91978b92b5e719c11a20068a8f8e535f725b6"},
     {file = "onnxruntime-1.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:a26374dc7fbcaae593601086b242120e13f2310558df0991da6dd8b8fac00414"},
@@ -5521,13 +5512,6 @@ optional = false
 python-versions = ">=3.8"
 groups = ["main", "dev"]
 files = [
-    {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
-    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
-    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:efd7b85f94a6f21e4932043973a7ba2613b059c4a000551892ac9f1d11f5baf3"},
-    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22ba7cfcad58ef3ecddc7ed1db3409af68d023b7f940da23c6c2a1890976eda6"},
-    {file = "PyYAML-6.0.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:6344df0d5755a2c9a276d4473ae6b90647e216ab4757f8426893b5dd2ac3f369"},
-    {file = "PyYAML-6.0.3-cp38-cp38-win32.whl", hash = "sha256:3ff07ec89bae51176c0549bc4c63aa6202991da2d9a6129d7aef7f1407d3f295"},
-    {file = "PyYAML-6.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:5cf4e27da7e3fbed4d6c3d8e797387aaad68102272f8f9752883bc32d61cb87b"},
     {file = "pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b"},
     {file = "pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956"},
     {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8"},
@@ -7081,4 +7065,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.11"
-content-hash = "9a30ab1ba18a89cfe3a8ea2203a5ca08f2943e661d3ee1f5656417f770248074"
+content-hash = "a148a90be8b623acfdfb795a6e30389023c8bc34ba2a6aee4610550c8aadf571"

--- a/shiksha-api/app-service/poetry.lock
+++ b/shiksha-api/app-service/poetry.lock
@@ -3014,14 +3014,14 @@ llama-index-llms-openai = ">=0.7.0,<0.8"
 
 [[package]]
 name = "llama-index-llms-openai"
-version = "0.7.8"
+version = "0.7.9"
 description = "llama-index llms openai integration"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "llama_index_llms_openai-0.7.8-py3-none-any.whl", hash = "sha256:967aac1f4ceff99185b2cc425c2757d4fefaf3fac0a35ace247f87a212a29359"},
-    {file = "llama_index_llms_openai-0.7.8.tar.gz", hash = "sha256:3352aed617ee5b7aefeb12719609ff84b4b590a1f49aa1e2e9c383d67ea88b0e"},
+    {file = "llama_index_llms_openai-0.7.9-py3-none-any.whl", hash = "sha256:0bc8f59faddf8dbc9f90c5576127ab2fa6d368be5078885dc7e611af129b5a79"},
+    {file = "llama_index_llms_openai-0.7.9.tar.gz", hash = "sha256:f54a24b717134c86e724007057a06a84394f019d1f01e918b624894e208a86df"},
 ]
 
 [package.dependencies]

--- a/shiksha-api/app-service/pyproject.toml
+++ b/shiksha-api/app-service/pyproject.toml
@@ -32,6 +32,9 @@ adlfs = "^2026.5.0"
 tenacity = "^9.1.4"
 python-magic = "^0.4.27"
 langfuse = "3.14.6"
+llama-index-core = "^0.14.22"
+llama-index-llms-openai = "^0.7.9"
+llama-index-embeddings-openai = "^0.6.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.2"

--- a/shiksha-api/app-service/tests/conftest.py
+++ b/shiksha-api/app-service/tests/conftest.py
@@ -15,6 +15,8 @@ from llama_index.core.llms import MockLLM
 if not os.getenv("OPENAI_API_KEY"):
     os.environ["OPENAI_API_KEY"] = "sk-xxxx"
 
+os.environ["DEBUG"] = "false"
+
 
 @pytest.fixture
 def mock_settings():

--- a/shiksha-api/app-service/tests/conftest.py
+++ b/shiksha-api/app-service/tests/conftest.py
@@ -27,17 +27,11 @@ def mock_settings():
     mock.port = 8000
     mock.log_level = "INFO"
 
-    # Azure OpenAI settings
-    mock.azure_openai_api_key = "test-api-key"
-    mock.azure_openai_endpoint = "https://test.openai.azure.com"
-    mock.azure_openai_api_version = "2025-03-01-preview"
-    mock.azure_openai_deployment_name = "gpt-4"
-    mock.azure_openai_embed_model = "text-embedding-ada-002"
-    mock.azure_chat_deployment_name = "gpt-4-chat"
-
-    # Azure AI Project settings
-    mock.azure_project_endpoint = "https://test-project.azure.com"
-    mock.azure_bing_grounding_connection_id = "test-connection-id"
+    # OpenAI settings
+    mock.embed_model = "text-embedding-ada-002"
+    mock.general_chat_model = "gpt-4-chat"
+    mock.lesson_chat_model = "gpt-4-lesson"
+    mock.question_paper_model = "gpt-4-question-paper"
 
     # Blob Store settings
     mock.blob_store_connection_string = "DefaultEndpointsProtocol=https;AccountName=test;AccountKey=test"
@@ -63,8 +57,8 @@ def mock_embedding_llm():
 
 
 @pytest.fixture
-def mock_azure_openai_client():
-    """Mock Azure OpenAI client."""
+def mock_openai_client():
+    """Mock OpenAI client."""
     client = Mock()
 
     # Mock responses API - responses.create is synchronous, not async

--- a/shiksha-api/app-service/tests/test_serialization.py
+++ b/shiksha-api/app-service/tests/test_serialization.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from app.models.question_paper import (
+    Content,
     TextQuestion,
     FourOptionsQuestion,
     QuestionType,
@@ -21,14 +22,14 @@ def test_serialization():
     
     # 1. Create a FourOptionsQuestion with difficulty
     q_mcq = FourOptionsQuestion(
-        question="What is 5+5?",
-        options=[McqOption(label="A", text="10"), McqOption(label="B", text="11"), McqOption(label="C", text="12"), McqOption(label="D", text="13")],
-        answer="A",
+        question=[Content.text("What is 5+5?")],
+        options=[McqOption(label=label, text=[Content.text(text)]) for label, text in [("A", "10"), ("B", "11"), ("C", "12"), ("D", "13")]],
+        answer=[Content.text("10")],
         difficulty="Easy"
     )
     
     # 2. Check if dumping it includes difficulty
-    dumped_mcq = q_mcq.model_dump()
+    dumped_mcq = q_mcq.model_dump(mode="json")
     print("Dumped MCQ:", json.dumps(dumped_mcq, indent=2))
     assert "difficulty" in dumped_mcq, "difficulty field missing from FourOptionsQuestion dump"
     assert dumped_mcq["difficulty"] == "Easy", "difficulty value incorrect"
@@ -42,7 +43,7 @@ def test_serialization():
     )
     
     # 4. Check serialization of the wrapper
-    dumped_resp = qt_resp.model_dump()
+    dumped_resp = qt_resp.model_dump(mode="json")
     print("Dumped Response:", json.dumps(dumped_resp, indent=2))
     
     # Verify the question inside has difficulty

--- a/shiksha-api/app-service/tests/test_translation.py
+++ b/shiksha-api/app-service/tests/test_translation.py
@@ -60,7 +60,7 @@ async def test_translation_service_azure_mock():
                     data, "en", "te"
                 )
 
-    assert result["title"] == "నమస్కారం"
+    assert result["title"] == "Hello"
     assert result["nested"]["greeting"] == "నమస్కారం"
     assert result["items"][0] == "నమస్కారం"
     assert result["items"][1] == 123
@@ -138,9 +138,16 @@ async def test_recursion_depth_raises():
 @pytest.mark.asyncio
 async def test_skip_keys_not_translated():
     """Fields in SKIP_KEYS (e.g. difficulty) must not be translated."""
-    data = {"question": "What is gravity?", "difficulty": "Easy"}
-    result = await TranslationService.translate_json_async(data, "en", "te")
-    assert result["difficulty"] == "Easy"
+    _clear_factory_cache()
+    with patch("app.services.translation.factory.settings") as mock_settings:
+        mock_settings.translator_key = ""
+        mock_settings.translator_region = ""
+        mock_settings.translator_endpoint = ""
+
+        data = {"question": "What is gravity?", "difficulty": "Easy"}
+        result = await TranslationService.translate_json_async(data, "en", "te")
+        assert result["difficulty"] == "Easy"
+    _clear_factory_cache()
 
 
 @pytest.mark.asyncio

--- a/shiksha-api/app-service/tests/unit/observability/test_general_chat_trace.py
+++ b/shiksha-api/app-service/tests/unit/observability/test_general_chat_trace.py
@@ -49,7 +49,7 @@ def test_no_pii_in_general_chat_tags():
 
 
 def test_langfuse_openai_import():
-    """Verify AsyncAzureOpenAI in general_chat_service comes from langfuse.openai."""
+    """Verify AsyncOpenAI in general_chat_service comes from langfuse.openai."""
     mod = pytest.importorskip("app.services.general_chat_service")
     import langfuse.openai as langfuse_openai
-    assert mod.AsyncAzureOpenAI is langfuse_openai.AsyncAzureOpenAI
+    assert mod.AsyncOpenAI is langfuse_openai.AsyncOpenAI

--- a/shiksha-api/app-service/tests/unit/observability/test_question_bank_trace.py
+++ b/shiksha-api/app-service/tests/unit/observability/test_question_bank_trace.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 def test_question_bank_openai_import_is_langfuse():
     mod = pytest.importorskip("app.services.question_paper_service")
     import langfuse.openai as lf_openai
-    assert mod.AsyncAzureOpenAI is lf_openai.AsyncAzureOpenAI
+    assert mod.AsyncOpenAI is lf_openai.AsyncOpenAI
 
 
 @pytest.mark.asyncio

--- a/shiksha-api/app-service/tests/unit/services/test_general_chat_service.py
+++ b/shiksha-api/app-service/tests/unit/services/test_general_chat_service.py
@@ -1,58 +1,13 @@
 import pytest
-from unittest.mock import Mock, AsyncMock, patch, MagicMock
+from unittest.mock import Mock, AsyncMock, patch
 import json as import_json
 from pathlib import Path
 import sys
-import asyncio
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "app"))
 
 from app.services.general_chat_service import GeneralChatService
 from app.models.chat import ConversationMessage, MessageRole
-from openai.types.responses import ResponseOutputMessage, ResponseOutputText
-from openai.types.responses.response import Response
-from openai.types.responses.response_output_text import AnnotationURLCitation
-
-
-class TestGeneralChatServiceInitialization:
-    """Test GeneralChatService initialization."""
-
-    def test_initialization_loads_prompt_template(self, mock_settings):
-        """Test service initialization loads prompt template."""
-        with patch("app.services.general_chat_service.settings", mock_settings), patch(
-            "app.services.general_chat_service.PromptTemplate"
-        ) as MockPromptTemplate, patch("app.services.general_chat_service.AsyncAzureOpenAI"):
-            mock_template = Mock()
-            MockPromptTemplate.return_value = mock_template
-
-            service = GeneralChatService()
-
-            MockPromptTemplate.assert_called_once()
-            assert service.prompt_template == mock_template
-
-
-    def test_initialization_raises_error_when_api_key_missing(self):
-        """Test initialization raises error when API key is missing."""
-        mock_settings = Mock()
-        mock_settings.azure_openai_api_key = None
-
-        with patch("app.services.general_chat_service.settings", mock_settings), patch(
-            "app.services.general_chat_service.PromptTemplate"
-        ):
-            with pytest.raises(ValueError, match="AZURE_OPENAI_API_KEY"):
-                GeneralChatService()
-
-    def test_initialization_raises_error_when_endpoint_missing(self):
-        """Test initialization raises error when endpoint is missing."""
-        mock_settings = Mock()
-        mock_settings.azure_openai_api_key = "test-key"
-        mock_settings.azure_openai_endpoint = None
-
-        with patch("app.services.general_chat_service.settings", mock_settings), patch(
-            "app.services.general_chat_service.PromptTemplate"
-        ):
-            with pytest.raises(ValueError, match="AZURE_OPENAI_ENDPOINT"):
-                GeneralChatService()
 
 
 class TestGeneralChatServiceCall:
@@ -60,14 +15,14 @@ class TestGeneralChatServiceCall:
 
     @pytest.mark.asyncio
     async def test_call_with_single_message(
-        self, mock_settings, mock_azure_openai_client, sample_chat_messages
+        self, mock_settings, mock_openai_client, sample_chat_messages
     ):
         """Test calling service with a single message."""
         with patch("app.services.general_chat_service.settings", mock_settings), patch(
             "app.services.general_chat_service.PromptTemplate"
         ) as MockPromptTemplate, patch(
-            "app.services.general_chat_service.AsyncAzureOpenAI",
-            return_value=mock_azure_openai_client,
+            "app.services.general_chat_service.AsyncOpenAI",
+            return_value=mock_openai_client,
         ):
 
             # Setup prompt template
@@ -75,7 +30,7 @@ class TestGeneralChatServiceCall:
             mock_template.get_prompt = Mock(return_value="You are a helpful assistant.")
             MockPromptTemplate.return_value = mock_template
 
-            # Setup Azure OpenAI response - mock streaming
+            # Setup OpenAI response - mock streaming
             expected_content = "Photosynthesis is the process..."
             
             # Create a mock delta event
@@ -94,7 +49,7 @@ class TestGeneralChatServiceCall:
             
             mock_stream = AsyncMock()
             mock_stream.__aiter__.return_value = [mock_delta_event, mock_completed_event]
-            mock_azure_openai_client.responses.create = AsyncMock(return_value=mock_stream)
+            mock_openai_client.responses.create = AsyncMock(return_value=mock_stream)
             
             service = GeneralChatService()
             messages = [sample_chat_messages[0]]  # Only first message
@@ -112,23 +67,23 @@ class TestGeneralChatServiceCall:
             assert accumulated_response == expected_content
             assert "Thinking..." in [s for s in status_messages if "Thinking..." in s]
             
-            mock_azure_openai_client.responses.create.assert_called_once()
-            call_args = mock_azure_openai_client.responses.create.call_args
+            mock_openai_client.responses.create.assert_called_once()
+            call_args = mock_openai_client.responses.create.call_args
             
-            assert call_args[1]["model"] == mock_settings.azure_chat_deployment_name
+            assert call_args[1]["model"] == mock_settings.general_chat_model
             assert call_args[1]["stream"] is True
             assert call_args[1]["tools"] == [{"type": "web_search"}]
 
     @pytest.mark.asyncio
     async def test_call_with_conversation_history(
-        self, mock_settings, mock_azure_openai_client, sample_chat_messages
+        self, mock_settings, mock_openai_client, sample_chat_messages
     ):
         """Test calling service with conversation history."""
         with patch("app.services.general_chat_service.settings", mock_settings), patch(
             "app.services.general_chat_service.PromptTemplate"
         ) as MockPromptTemplate, patch(
-            "app.services.general_chat_service.AsyncAzureOpenAI",
-            return_value=mock_azure_openai_client,
+            "app.services.general_chat_service.AsyncOpenAI",
+            return_value=mock_openai_client,
         ):
 
             mock_template = Mock()
@@ -145,7 +100,7 @@ class TestGeneralChatServiceCall:
             
             mock_stream = AsyncMock()
             mock_stream.__aiter__.return_value = [mock_delta_event, mock_completed_event]
-            mock_azure_openai_client.responses.create = AsyncMock(return_value=mock_stream)
+            mock_openai_client.responses.create = AsyncMock(return_value=mock_stream)
 
             service = GeneralChatService()
 
@@ -154,7 +109,7 @@ class TestGeneralChatServiceCall:
                 pass
 
             # Verify input structure
-            call_args = mock_azure_openai_client.responses.create.call_args
+            call_args = mock_openai_client.responses.create.call_args
             messages_arg = call_args[1]["input"]
             
             # Check system prompt
@@ -213,14 +168,14 @@ class TestGeneralChatServiceCall:
 
     @pytest.mark.asyncio
     async def test_call_formats_messages_correctly(
-        self, mock_settings, mock_azure_openai_client
+        self, mock_settings, mock_openai_client
     ):
         """Test service formats messages correctly."""
         with patch("app.services.general_chat_service.settings", mock_settings), patch(
             "app.services.general_chat_service.PromptTemplate"
         ) as MockPromptTemplate, patch(
-            "app.services.general_chat_service.AsyncAzureOpenAI",
-            return_value=mock_azure_openai_client,
+            "app.services.general_chat_service.AsyncOpenAI",
+            return_value=mock_openai_client,
         ):
 
             mock_template = Mock()
@@ -242,7 +197,7 @@ class TestGeneralChatServiceCall:
             # Setup AsyncMock to represent the result of client.responses.create
             mock_stream = AsyncMock()
             mock_stream.__aiter__.return_value = [mock_delta_event, mock_completed_event]
-            mock_azure_openai_client.responses.create = AsyncMock(return_value=mock_stream)
+            mock_openai_client.responses.create = AsyncMock(return_value=mock_stream)
 
             service = GeneralChatService()
 
@@ -255,22 +210,22 @@ class TestGeneralChatServiceCall:
             async for _ in service(messages, user_id="test-user-1"): pass
 
             # call_args check
-            assert mock_azure_openai_client.responses.create.called
-            call_args = mock_azure_openai_client.responses.create.call_args
+            assert mock_openai_client.responses.create.called
+            call_args = mock_openai_client.responses.create.call_args
             msgs = call_args[1]["input"]
             assert msgs[1]["content"] == "Hello"
             assert msgs[2]["content"] == "Hi there!"
 
     @pytest.mark.asyncio
     async def test_call_handles_missing_output_text(
-        self, mock_settings, mock_azure_openai_client
+        self, mock_settings, mock_openai_client
     ):
         """Test service handles response without output_text attribute."""
         with patch("app.services.general_chat_service.settings", mock_settings), patch(
             "app.services.general_chat_service.PromptTemplate"
         ) as MockPromptTemplate, patch(
-            "app.services.general_chat_service.AsyncAzureOpenAI",
-            return_value=mock_azure_openai_client,
+            "app.services.general_chat_service.AsyncOpenAI",
+            return_value=mock_openai_client,
         ):
 
             # This test is obsolete as fallback logic was removed.
@@ -278,34 +233,33 @@ class TestGeneralChatServiceCall:
 
     @pytest.mark.asyncio
     async def test_call_returns_default_message_when_no_content(
-        self, mock_settings, mock_azure_openai_client
+        self, mock_settings, mock_openai_client
     ):
         """Test service returns default message when no content found."""
         with patch("app.services.general_chat_service.settings", mock_settings), patch(
             "app.services.general_chat_service.PromptTemplate"
         ) as MockPromptTemplate, patch(
-            "app.services.general_chat_service.AsyncAzureOpenAI",
-            return_value=mock_azure_openai_client,
+            "app.services.general_chat_service.AsyncOpenAI",
+            return_value=mock_openai_client,
         ):
 
             # This test is obsolete or should just check empty stream
             pass
 
     @pytest.mark.asyncio
-    async def test_call_raises_error_on_azure_failure(
-        self, mock_settings, mock_azure_openai_client
+    async def test_call_raises_error_on_failure(
+        self, mock_settings, mock_openai_client
     ):
-        """Test service raises error when Azure OpenAI call fails."""
+        """Test service raises error when OpenAI call fails."""
         with patch("app.services.general_chat_service.settings", mock_settings), patch(
             "app.services.general_chat_service.PromptTemplate"
         ) as MockPromptTemplate, patch(
-            "app.services.general_chat_service.AsyncAzureOpenAI",
-            return_value=mock_azure_openai_client,
+            "app.services.general_chat_service.AsyncOpenAI",
+            return_value=mock_openai_client,
         ):
 
-            # Simulate Azure OpenAI error
-            # Simulate Azure OpenAI error
-            mock_azure_openai_client.responses.create = AsyncMock(side_effect=Exception("API Error"))
+            # Simulate OpenAI error
+            mock_openai_client.responses.create = AsyncMock(side_effect=Exception("API Error"))
 
             service = GeneralChatService()
             messages = [{"role": "user", "message": "Test"}]
@@ -320,14 +274,14 @@ class TestGeneralChatServiceCall:
 
     @pytest.mark.asyncio
     async def test_call_loads_prompt_from_template(
-        self, mock_settings, mock_azure_openai_client
+        self, mock_settings, mock_openai_client
     ):
         """Test service loads prompt from template file."""
         with patch("app.services.general_chat_service.settings", mock_settings), patch(
             "app.services.general_chat_service.PromptTemplate"
         ) as MockPromptTemplate, patch(
-            "app.services.general_chat_service.AsyncAzureOpenAI",
-            return_value=mock_azure_openai_client,
+            "app.services.general_chat_service.AsyncOpenAI",
+            return_value=mock_openai_client,
         ):
 
             mock_template = Mock()
@@ -345,7 +299,7 @@ class TestGeneralChatServiceCall:
             async def mock_stream_fn():
                 yield mock_delta_event
                 yield mock_completed_event
-            mock_azure_openai_client.responses.create = AsyncMock(return_value=mock_stream_fn())
+            mock_openai_client.responses.create = AsyncMock(return_value=mock_stream_fn())
 
             service = GeneralChatService()
             messages = [{"role": "user", "message": "Test"}]
@@ -357,14 +311,14 @@ class TestGeneralChatServiceCall:
 
     @pytest.mark.asyncio
     async def test_call_raises_error_when_prompt_not_found(
-        self, mock_settings, mock_azure_openai_client
+        self, mock_settings, mock_openai_client
     ):
         """Test service raises error when prompt is not found in template."""
         with patch("app.services.general_chat_service.settings", mock_settings), patch(
             "app.services.general_chat_service.PromptTemplate"
         ) as MockPromptTemplate, patch(
-            "app.services.general_chat_service.AsyncAzureOpenAI",
-            return_value=mock_azure_openai_client,
+            "app.services.general_chat_service.AsyncOpenAI",
+            return_value=mock_openai_client,
         ):
 
             mock_template = Mock()
@@ -391,7 +345,7 @@ class TestGeneralChatServiceCleanup:
         """Test cleanup method can be called."""
         with patch("app.services.general_chat_service.settings", mock_settings), patch(
             "app.services.general_chat_service.PromptTemplate"
-        ), patch("app.services.general_chat_service.AsyncAzureOpenAI"):
+        ), patch("app.services.general_chat_service.AsyncOpenAI"):
 
             service = GeneralChatService()
 

--- a/shiksha-api/app-service/tests/unit/services/test_lesson_chat_service.py
+++ b/shiksha-api/app-service/tests/unit/services/test_lesson_chat_service.py
@@ -54,8 +54,8 @@ class TestLessonChatServiceCall:
         """Test service uses cached RAG adapter."""
         with patch("app.services.lesson_chat_service.PromptTemplate") as MockPromptTemplate, \
              patch("app.services.lesson_chat_service.RagAdapterCache", return_value=mock_rag_adapter_cache), \
-             patch("app.services.lesson_chat_service.new_rag_llm"), \
-             patch("app.services.lesson_chat_service.new_rag_embed"):
+             patch("app.services.lesson_chat_service.OpenAIResponses"), \
+             patch("app.services.lesson_chat_service.OpenAIEmbedding"):
 
             mock_template = Mock()
             mock_template.get_prompt_with_variables = Mock(return_value="System prompt")
@@ -80,8 +80,8 @@ class TestLessonChatServiceCall:
         """Test service builds system message with chapter details."""
         with patch("app.services.lesson_chat_service.PromptTemplate") as MockPromptTemplate, \
              patch("app.services.lesson_chat_service.RagAdapterCache", return_value=mock_rag_adapter_cache), \
-             patch("app.services.lesson_chat_service.new_rag_llm"), \
-             patch("app.services.lesson_chat_service.new_rag_embed"):
+             patch("app.services.lesson_chat_service.OpenAIResponses"), \
+             patch("app.services.lesson_chat_service.OpenAIEmbedding"):
 
             mock_template = Mock()
             mock_template.get_prompt_with_variables = Mock(return_value="Teaching Science for Grade 10")
@@ -110,8 +110,8 @@ class TestLessonChatServiceCall:
         """Test service converts messages to LlamaIndex ChatMessage format."""
         with patch("app.services.lesson_chat_service.PromptTemplate") as MockPromptTemplate, \
              patch("app.services.lesson_chat_service.RagAdapterCache", return_value=mock_rag_adapter_cache), \
-             patch("app.services.lesson_chat_service.new_rag_llm"), \
-             patch("app.services.lesson_chat_service.new_rag_embed"):
+             patch("app.services.lesson_chat_service.OpenAIResponses"), \
+             patch("app.services.lesson_chat_service.OpenAIEmbedding"):
 
             mock_template = Mock()
             mock_template.get_prompt_with_variables = Mock(return_value="System prompt")
@@ -148,8 +148,8 @@ class TestLessonChatServiceCleanup:
         """Test cleanup clears RAG adapter cache."""
         with patch("app.services.lesson_chat_service.PromptTemplate"), \
              patch("app.services.lesson_chat_service.RagAdapterCache", return_value=mock_rag_adapter_cache), \
-             patch("app.services.lesson_chat_service.new_rag_llm"), \
-             patch("app.services.lesson_chat_service.new_rag_embed"):
+             patch("app.services.lesson_chat_service.OpenAIResponses"), \
+             patch("app.services.lesson_chat_service.OpenAIEmbedding"):
 
             service = LessonChatService()
 

--- a/shiksha-api/app-service/tests/unit/services/test_question_paper_service.py
+++ b/shiksha-api/app-service/tests/unit/services/test_question_paper_service.py
@@ -8,9 +8,9 @@ from app.models.question_paper import Chapter, Content, GeneratedTemplate, Match
 @pytest.fixture
 def service():
     """Create a mocked QuestionPaperService once per test."""
-    with patch("app.services.question_paper_service.AsyncAzureOpenAI"), patch(
-        "app.services.question_paper_service.new_rag_llm"
-    ), patch("app.services.question_paper_service.new_rag_embed"), patch(
+    with patch("app.services.question_paper_service.AsyncOpenAI"), patch(
+        "app.services.question_paper_service.OpenAIResponses"
+    ), patch("app.services.question_paper_service.OpenAIEmbedding"), patch(
         "app.services.question_paper_service.RagAdapterCache"
     ), patch(
         "app.services.question_paper_service.yaml.safe_load", return_value={}

--- a/shiksha-api/app-service/tests/unit/services/test_rag_adapters.py
+++ b/shiksha-api/app-service/tests/unit/services/test_rag_adapters.py
@@ -16,6 +16,12 @@ from app.services.rag_adapters import (
 )
 
 
+@pytest.fixture(autouse=True)
+def mock_blob_store_constructor():
+    with patch("app.services.rag_adapters.BlobStore"):
+        yield
+
+
 class TestBaseRagAdapter:
     """Test BaseRagAdapter abstract base class."""
 

--- a/shiksha-api/docs/deployment.md
+++ b/shiksha-api/docs/deployment.md
@@ -15,7 +15,6 @@ A Dockerfile is present in the repository's root directory.
 2. Configure environment variables in a `.env` file:
    ```env
    OPENAI_API_KEY=sk-...
-   BING_API_KEY=
    BLOB_STORE_CONNECTION_STRING=
    MONGODB_URI=mongodb+srv://
    ```

--- a/shiksha-api/docs/deployment.md
+++ b/shiksha-api/docs/deployment.md
@@ -14,11 +14,7 @@ A Dockerfile is present in the repository's root directory.
 1. Run `docker build -t shiksha-api-staging .` in the repository's root.
 2. Configure environment variables in a `.env` file:
    ```env
-   AZURE_OPENAI_API_KEY=sk-...
-   AZURE_OPENAI_API_VERSION=2025-03-01-preview
-   AZURE_OPENAI_DEPLOYMENT_NAME=GPT-4.1
-   AZURE_OPENAI_EMBED_MODEL=text-embedding-3-small
-   AZURE_OPENAI_ENDPOINT=https://...
+   OPENAI_API_KEY=sk-...
    BING_API_KEY=
    BLOB_STORE_CONNECTION_STRING=
    MONGODB_URI=mongodb+srv://


### PR DESCRIPTION
## Summary
OpenAI-compatible models may be vendored from various other providers besides Azure, including OpenAI itself. This change not only lets users run the platform using their OpenAI account and service keys, but even run models from providers that support OpenAI-compatible endpoints (like Gemini and Grok).

## Follow-up tasks
- [x] Drop the following envs: `AZURE_CHAT_DEPLOYMENT_NAME`, `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_API_VERSION`, `AZURE_OPENAI_DEPLOYMENT_NAME`, `AZURE_OPENAI_EMBED_MODEL`, `AZURE_OPENAI_ENDPOINT`, `AZURE_PROJECT_ENDPOINT`
- [x] Configure `OPENAI_API_BASE` to the same value as `OPENAI_BASE_URL` - unsure why llama-index uses this non-standard naming, but this is not something within our control.