### PR TITLE
lp: fix ppts are sourced from edited content instead of original content

### DIFF
--- a/shiksha-website/shiksha-backend/controllers/teacher.lesson.plan.controller.js
+++ b/shiksha-website/shiksha-backend/controllers/teacher.lesson.plan.controller.js
@@ -187,8 +187,11 @@ class TeacherLessonPlanController extends BaseController {
 			return res.status(200).json(response.data[0]);
 		}
 
-		const lessonPlan = await this.teacherLessonPlanManager.teacherLessonPlanDao.getLessonPlanById(teacherId, lessonPlanId);
-		if (!lessonPlan) {
+		const [authorized, lessonPlan] = await Promise.all([
+			this.teacherLessonPlanManager.teacherLessonPlanDao.getLessonPlanById(teacherId, lessonPlanId), // test whether teacher have access to this lp
+			this.teacherLessonPlanManager.masterLessonDao.getById(lessonPlanId)
+		]);
+		if (!authorized || !lessonPlan) {
 			return res.status(404).json({ message: "Lesson plan not found" });
 		}
 


### PR DESCRIPTION
## Summary
Lesson plans have a button that lets teachers generate presentations from the lesson plan content. Existing flow retrieves lesson plan content from `db.teacherlessonplans` instead of `db.masterlessons` - the latter is an immutable version of the former.

<img width="1919" height="939" alt="image" src="https://github.com/user-attachments/assets/bf2986aa-33a5-44a6-a85f-a02bcc57683f" />
<p align="center">Teachers can edit lesson plan for themself after generating one. These edits are stored in <code>db.teacherlessonplans</code>.</p>