### PR TITLE
ui: fix mediums listed in lowercase

### DIFF
--- a/shiksha-website/shiksha-frontend/src/app/shared/components/lesson-plan-resource-details/lesson-plan-resource-details.component.html
+++ b/shiksha-website/shiksha-frontend/src/app/shared/components/lesson-plan-resource-details/lesson-plan-resource-details.component.html
@@ -16,7 +16,7 @@
 													[dropDownValues]="boardDropdownOptions" [config]="boardDropdownconfig"
 													[submitted]="submitted"></app-form-dropdown>
 									</div>
-									<div class="cursor-pointer">
+									<div class="cursor-pointer capitalize">
 										<app-form-dropdown [dropDownControlName]="'medium'" (valueChange)="onMediumChange($event)"
 												[dropDownCtrl]="convertToFormControl(f['medium'])" [dropDownValues]="mediumDropdownOptions"
 												[config]="mediumDropdownconfig" [submitted]="submitted"></app-form-dropdown>


### PR DESCRIPTION
## Summary

Lesson resource and lesson plan flows have a "Medium" selection dropdown, but the values are listed in lowercase. This PR fixes the casing across both flows.

<img width="1919" height="938" alt="image" src="https://github.com/user-attachments/assets/6797da3b-f063-44dc-bc28-a78109e3ff07" />
<p align="center">"Medium" dropdown values are presently displayed in lowercase.</p>
