### PR TITLE
Update baseline survey flow for academic year 2026

### DIFF
--- a/shiksha-website/shiksha-backend/__tests__/unit/controllers/baselineSurvey.controller.test.js
+++ b/shiksha-website/shiksha-backend/__tests__/unit/controllers/baselineSurvey.controller.test.js
@@ -13,6 +13,7 @@ describe("BaselineSurveyController", () => {
     mockReq = {
       user: { _id: "user-123" },
       body: {},
+      originalUrl: "/api/baseline-surveys",
     };
 
     mockRes = {
@@ -25,7 +26,7 @@ describe("BaselineSurveyController", () => {
     it("should check if survey is completed successfully", async () => {
       const mockResult = {
         success: true,
-        data: { completed: true },
+        data: { completed: true, maxReminders: 2 },
       };
       baselineSurveyManager.checkCompleted = jest.fn().mockResolvedValue(mockResult);
 
@@ -119,10 +120,11 @@ describe("BaselineSurveyController", () => {
       expect(baselineSurveyManager.submitSurvey).not.toHaveBeenCalled();
     });
 
-    it("should return 409 when survey already submitted", async () => {
+    it("should return 409 when result has ALREADY_SUBMITTED code", async () => {
       const mockResult = {
         success: false,
         message: "Already submitted for this academic year",
+        code: "ALREADY_SUBMITTED",
       };
       baselineSurveyManager.submitSurvey = jest.fn().mockResolvedValue(mockResult);
       mockReq.body = { answers: {} };
@@ -133,7 +135,7 @@ describe("BaselineSurveyController", () => {
       expect(mockRes.json).toHaveBeenCalledWith(mockResult);
     });
 
-    it("should return 400 when submission fails", async () => {
+    it("should return 400 when submission fails without ALREADY_SUBMITTED code", async () => {
       const mockResult = {
         success: false,
         message: "Submission failed",
@@ -169,6 +171,56 @@ describe("BaselineSurveyController", () => {
       mockReq.body = { answers: {} };
 
       await baselineSurveyController.submitSurvey(mockReq, mockRes);
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: "Server error",
+        })
+      );
+    });
+  });
+
+  describe("remindLater", () => {
+    it("should return 200 when remind later succeeds", async () => {
+      const mockResult = {
+        success: true,
+        data: { remindLaterCount: 1, isMandatory: false },
+      };
+      baselineSurveyManager.incrementRemindLater = jest.fn().mockResolvedValue(mockResult);
+
+      await baselineSurveyController.remindLater(mockReq, mockRes);
+
+      expect(baselineSurveyManager.incrementRemindLater).toHaveBeenCalledWith("user-123");
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith(mockResult);
+    });
+
+    it("should return 401 when user is not authenticated", async () => {
+      mockReq.user = null;
+
+      await baselineSurveyController.remindLater(mockReq, mockRes);
+
+      expect(mockRes.status).toHaveBeenCalledWith(401);
+    });
+
+    it("should return 400 when manager returns failure", async () => {
+      const mockResult = {
+        success: false,
+        message: "Missing userId",
+      };
+      baselineSurveyManager.incrementRemindLater = jest.fn().mockResolvedValue(mockResult);
+
+      await baselineSurveyController.remindLater(mockReq, mockRes);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+    });
+
+    it("should return 500 on exception", async () => {
+      baselineSurveyManager.incrementRemindLater = jest.fn().mockRejectedValue(new Error("DB down"));
+
+      await baselineSurveyController.remindLater(mockReq, mockRes);
 
       expect(mockRes.status).toHaveBeenCalledWith(500);
       expect(mockRes.json).toHaveBeenCalledWith(

--- a/shiksha-website/shiksha-backend/__tests__/unit/managers/baselineSurvey.manager.test.js
+++ b/shiksha-website/shiksha-backend/__tests__/unit/managers/baselineSurvey.manager.test.js
@@ -322,21 +322,21 @@ describe("BaselineSurveyManager", () => {
       expect(result.data.isMandatory).toBe(false);
     });
 
-    it("should set isMandatory=true when reminder count reaches MAX_REMIND_LATER (3)", async () => {
+    it("should set isMandatory=true when reminder count reaches MAX_REMIND_LATER (2)", async () => {
       mockDao.existsByUser.mockResolvedValue(false);
-      mockReminderDao.getCount.mockResolvedValue(2);
-      mockReminderDao.increment.mockResolvedValue({ remindLaterCount: 3 });
+      mockReminderDao.getCount.mockResolvedValue(1);
+      mockReminderDao.increment.mockResolvedValue({ remindLaterCount: 2 });
 
       const result = await baselineSurveyManager.incrementRemindLater("user-123");
 
       expect(result.success).toBe(true);
-      expect(result.data.remindLaterCount).toBe(3);
+      expect(result.data.remindLaterCount).toBe(2);
       expect(result.data.isMandatory).toBe(true);
     });
 
     it("should not increment reminder count if survey already completed", async () => {
       mockDao.existsByUser.mockResolvedValue(true);
-      mockReminderDao.getCount.mockResolvedValue(2);
+      mockReminderDao.getCount.mockResolvedValue(1);
 
       const result = await baselineSurveyManager.incrementRemindLater("user-123");
 
@@ -344,19 +344,19 @@ describe("BaselineSurveyManager", () => {
       expect(result.success).toBe(true);
       expect(result.message).toBe("Survey already completed");
       expect(result.data.completed).toBe(true);
-      expect(result.data.remindLaterCount).toBe(2);
+      expect(result.data.remindLaterCount).toBe(1);
     });
 
     it("should not increment past MAX_REMIND_LATER (ceiling)", async () => {
       mockDao.existsByUser.mockResolvedValue(false);
-      mockReminderDao.getCount.mockResolvedValue(3);
+      mockReminderDao.getCount.mockResolvedValue(2);
 
       const result = await baselineSurveyManager.incrementRemindLater("user-123");
 
       expect(mockReminderDao.increment).not.toHaveBeenCalled();
       expect(result.success).toBe(true);
       expect(result.message).toBe("Maximum reminders reached");
-      expect(result.data.remindLaterCount).toBe(3);
+      expect(result.data.remindLaterCount).toBe(2);
       expect(result.data.isMandatory).toBe(true);
     });
 

--- a/shiksha-website/shiksha-backend/__tests__/unit/managers/baselineSurvey.manager.test.js
+++ b/shiksha-website/shiksha-backend/__tests__/unit/managers/baselineSurvey.manager.test.js
@@ -1,18 +1,27 @@
 const BaselineSurveyDao = require("../../../dao/baselineSurvey.dao");
+const BaselineSurveyReminderDao = require("../../../dao/baselineSurveyReminder.dao");
 process.env.BASELINE_SURVEY = "true";
 
 jest.mock("../../../dao/baselineSurvey.dao");
+jest.mock("../../../dao/baselineSurveyReminder.dao");
+jest.mock("../../../config/loggers", () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn() }));
 
-// Create mock DAO before requiring the manager
+// Create mock DAOs before requiring the manager
 const mockDao = {
   existsByUser: jest.fn(),
   findByUser: jest.fn(),
   createSurvey: jest.fn(),
 };
 
-BaselineSurveyDao.mockImplementation(() => mockDao);
+const mockReminderDao = {
+  getCount: jest.fn(),
+  increment: jest.fn(),
+};
 
-// Import manager after mocking to ensure the instance gets the mocked DAO
+BaselineSurveyDao.mockImplementation(() => mockDao);
+BaselineSurveyReminderDao.mockImplementation(() => mockReminderDao);
+
+// Import manager after mocking to ensure the instance gets the mocked DAOs
 const baselineSurveyManager = require("../../../managers/baselineSurvey.manager");
 
 describe("BaselineSurveyManager", () => {
@@ -23,6 +32,7 @@ describe("BaselineSurveyManager", () => {
   describe("checkCompleted", () => {
     it("should return completed status when survey exists", async () => {
       mockDao.existsByUser.mockResolvedValue(true);
+      mockReminderDao.getCount.mockResolvedValue(0);
 
       const result = await baselineSurveyManager.checkCompleted("user-123");
 
@@ -33,6 +43,7 @@ describe("BaselineSurveyManager", () => {
 
     it("should return not completed when survey does not exist", async () => {
       mockDao.existsByUser.mockResolvedValue(false);
+      mockReminderDao.getCount.mockResolvedValue(0);
 
       const result = await baselineSurveyManager.checkCompleted("user-123");
 
@@ -55,6 +66,45 @@ describe("BaselineSurveyManager", () => {
 
       expect(result.success).toBe(false);
       expect(result.message).toBe("Server error");
+    });
+
+    it("should include maxReminders in the response data", async () => {
+      mockDao.existsByUser.mockResolvedValue(false);
+      mockReminderDao.getCount.mockResolvedValue(1);
+
+      const result = await baselineSurveyManager.checkCompleted("user-123");
+
+      expect(result.success).toBe(true);
+      expect(result.data.maxReminders).toBeDefined();
+      expect(typeof result.data.maxReminders).toBe("number");
+    });
+
+    it("should set isMandatory=true when remindLaterCount >= maxReminders", async () => {
+      mockDao.existsByUser.mockResolvedValue(false);
+      mockReminderDao.getCount.mockResolvedValue(3);
+
+      const result = await baselineSurveyManager.checkCompleted("user-123");
+
+      expect(result.data.isMandatory).toBe(true);
+    });
+  });
+
+  describe("getRemindLaterCount", () => {
+    it("should return count from the reminder DAO", async () => {
+      mockReminderDao.getCount.mockResolvedValue(2);
+
+      const count = await baselineSurveyManager.getRemindLaterCount("user-123", 2026);
+
+      expect(mockReminderDao.getCount).toHaveBeenCalledWith("user-123", 2026);
+      expect(count).toBe(2);
+    });
+
+    it("should let DB errors propagate (not swallow)", async () => {
+      mockReminderDao.getCount.mockRejectedValue(new Error("DB connection lost"));
+
+      await expect(
+        baselineSurveyManager.getRemindLaterCount("user-123", 2026)
+      ).rejects.toThrow("DB connection lost");
     });
   });
 
@@ -99,13 +149,14 @@ describe("BaselineSurveyManager", () => {
       expect(mockDao.findByUser).not.toHaveBeenCalled();
     });
 
-    it("should return error when survey already submitted", async () => {
+    it("should return ALREADY_SUBMITTED code when survey already submitted", async () => {
       mockDao.findByUser.mockResolvedValue({ _id: "existing-survey" });
 
       const result = await baselineSurveyManager.submitSurvey(mockUserId, mockBody);
 
       expect(mockDao.findByUser).toHaveBeenCalledWith(mockUserId, expect.any(Number));
       expect(result.success).toBe(false);
+      expect(result.code).toBe("ALREADY_SUBMITTED");
       expect(result.message).toBe("Already submitted for this academic year");
       expect(mockDao.createSurvey).not.toHaveBeenCalled();
     });
@@ -116,15 +167,15 @@ describe("BaselineSurveyManager", () => {
 
       const bodyWithOther = {
         ...mockBody,
-        lessonPlanComponents: ["Component 1", "Others"],
-        otherLessonPlanComponent: "Custom component",
+        lessonPlanComponents: ["Component 1", "Other"],
+        lessonPlanComponentsOther: "Custom component",
       };
 
       await baselineSurveyManager.submitSurvey(mockUserId, bodyWithOther);
 
       expect(mockDao.createSurvey).toHaveBeenCalledWith(
         expect.objectContaining({
-          lessonPlanComponents: ["Component 1", "Others: Custom component"],
+          lessonPlanComponents: ["Component 1", "Other: Custom component"],
         }),
         null
       );
@@ -136,15 +187,15 @@ describe("BaselineSurveyManager", () => {
 
       const bodyWithOther = {
         ...mockBody,
-        resourcesUsed: ["Resource 1", "Others"],
-        otherResourceUsed: "Custom resource",
+        resourcesUsed: ["Resource 1", "Other"],
+        resourcesUsedOther: "Custom resource",
       };
 
       await baselineSurveyManager.submitSurvey(mockUserId, bodyWithOther);
 
       expect(mockDao.createSurvey).toHaveBeenCalledWith(
         expect.objectContaining({
-          resourcesUsed: ["Resource 1", "Others: Custom resource"],
+          resourcesUsed: ["Resource 1", "Other: Custom resource"],
         }),
         null
       );
@@ -156,8 +207,8 @@ describe("BaselineSurveyManager", () => {
 
       const bodyWithOther = {
         ...mockBody,
-        timePerLessonPlan: "Others",
-        otherTimePerLessonPlan: "45 minutes",
+        timePerLessonPlan: "Other",
+        timePerLessonPlanOther: "45 minutes",
       };
 
       await baselineSurveyManager.submitSurvey(mockUserId, bodyWithOther);
@@ -176,8 +227,8 @@ describe("BaselineSurveyManager", () => {
 
       const bodyWithOther = {
         ...mockBody,
-        timeForAssessments: "Others",
-        otherTimeForAssessments: "20 minutes",
+        timeForAssessments: "Other",
+        timeForAssessmentsOther: "20 minutes",
       };
 
       await baselineSurveyManager.submitSurvey(mockUserId, bodyWithOther);
@@ -211,7 +262,7 @@ describe("BaselineSurveyManager", () => {
       );
     });
 
-    it("should handle duplicate key error (11000)", async () => {
+    it("should return ALREADY_SUBMITTED code for duplicate key error (11000)", async () => {
       mockDao.findByUser.mockResolvedValue(null);
       const duplicateError = new Error("Duplicate");
       duplicateError.code = 11000;
@@ -220,7 +271,7 @@ describe("BaselineSurveyManager", () => {
       const result = await baselineSurveyManager.submitSurvey(mockUserId, mockBody);
 
       expect(result.success).toBe(false);
-      expect(result.message).toBe("Already submitted for this academic year");
+      expect(result.code).toBe("ALREADY_SUBMITTED");
     });
 
     it("should handle general errors", async () => {
@@ -241,6 +292,92 @@ describe("BaselineSurveyManager", () => {
       await baselineSurveyManager.submitSurvey(mockUserId, mockBody, mockSession);
 
       expect(mockDao.createSurvey).toHaveBeenCalledWith(expect.any(Object), mockSession);
+    });
+  });
+
+  describe("incrementRemindLater", () => {
+    beforeEach(() => {
+      mockReminderDao.getCount.mockReset();
+      mockReminderDao.increment.mockReset();
+    });
+
+    it("should return error when userId is missing", async () => {
+      const result = await baselineSurveyManager.incrementRemindLater(null);
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Missing userId");
+      expect(mockDao.existsByUser).not.toHaveBeenCalled();
+    });
+
+    it("should increment reminder count for a non-completed user", async () => {
+      mockDao.existsByUser.mockResolvedValue(false);
+      mockReminderDao.getCount.mockResolvedValue(0);
+      mockReminderDao.increment.mockResolvedValue({ remindLaterCount: 1 });
+
+      const result = await baselineSurveyManager.incrementRemindLater("user-123");
+
+      expect(mockDao.existsByUser).toHaveBeenCalledWith("user-123", expect.any(Number));
+      expect(mockReminderDao.increment).toHaveBeenCalledWith("user-123", expect.any(Number), null);
+      expect(result.success).toBe(true);
+      expect(result.data.remindLaterCount).toBe(1);
+      expect(result.data.isMandatory).toBe(false);
+    });
+
+    it("should set isMandatory=true when reminder count reaches MAX_REMIND_LATER (3)", async () => {
+      mockDao.existsByUser.mockResolvedValue(false);
+      mockReminderDao.getCount.mockResolvedValue(2);
+      mockReminderDao.increment.mockResolvedValue({ remindLaterCount: 3 });
+
+      const result = await baselineSurveyManager.incrementRemindLater("user-123");
+
+      expect(result.success).toBe(true);
+      expect(result.data.remindLaterCount).toBe(3);
+      expect(result.data.isMandatory).toBe(true);
+    });
+
+    it("should not increment reminder count if survey already completed", async () => {
+      mockDao.existsByUser.mockResolvedValue(true);
+      mockReminderDao.getCount.mockResolvedValue(2);
+
+      const result = await baselineSurveyManager.incrementRemindLater("user-123");
+
+      expect(mockReminderDao.increment).not.toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      expect(result.message).toBe("Survey already completed");
+      expect(result.data.completed).toBe(true);
+      expect(result.data.remindLaterCount).toBe(2);
+    });
+
+    it("should not increment past MAX_REMIND_LATER (ceiling)", async () => {
+      mockDao.existsByUser.mockResolvedValue(false);
+      mockReminderDao.getCount.mockResolvedValue(3);
+
+      const result = await baselineSurveyManager.incrementRemindLater("user-123");
+
+      expect(mockReminderDao.increment).not.toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      expect(result.message).toBe("Maximum reminders reached");
+      expect(result.data.remindLaterCount).toBe(3);
+      expect(result.data.isMandatory).toBe(true);
+    });
+
+    it("should pass session parameter to reminder DAO", async () => {
+      mockDao.existsByUser.mockResolvedValue(false);
+      mockReminderDao.getCount.mockResolvedValue(0);
+      mockReminderDao.increment.mockResolvedValue({ remindLaterCount: 1 });
+
+      const mockSession = { id: "session-123" };
+      await baselineSurveyManager.incrementRemindLater("user-123", mockSession);
+
+      expect(mockReminderDao.increment).toHaveBeenCalledWith("user-123", expect.any(Number), mockSession);
+    });
+
+    it("should handle database errors gracefully", async () => {
+      mockDao.existsByUser.mockRejectedValue(new Error("DB failure"));
+
+      const result = await baselineSurveyManager.incrementRemindLater("user-123");
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Server error");
     });
   });
 });

--- a/shiksha-website/shiksha-backend/__tests__/unit/routes/routes.test.js
+++ b/shiksha-website/shiksha-backend/__tests__/unit/routes/routes.test.js
@@ -121,6 +121,7 @@ const setupSharedMocks = () => {
       jest.doMock(p, () => ({
         checkIfCompleted: jest.fn(),
         submitSurvey: jest.fn(),
+        remindLater: jest.fn(),
       }));
     } else {
       jest.doMock(p, () => mockControllerClass());

--- a/shiksha-website/shiksha-backend/__tests__/unit/validations/baselineSurvey.validation.test.js
+++ b/shiksha-website/shiksha-backend/__tests__/unit/validations/baselineSurvey.validation.test.js
@@ -1,0 +1,99 @@
+const {
+  validateSubmitSurvey,
+  validateRemindLater,
+} = require("../../../validations/baselineSurvey.validation");
+
+describe("Baseline Survey Validation", () => {
+  let mockReq;
+  let mockRes;
+  let mockNext;
+
+  beforeEach(() => {
+    mockReq = {
+      body: {},
+    };
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+    mockNext = jest.fn();
+  });
+
+  const validSurveyData = {
+    plans: ["Lesson Plan template of Shiksha Sopan"],
+    plansOther: "",
+    devices: ["Mobile"],
+    devicesOther: "",
+    weeklyLessonPlans: "3-5 plans",
+    lessonPlanComponents: ["Learning objectives", "Assessment questions"],
+    otherLessonPlanComponent: "",
+    lessonPlanComponentsOther: "",
+    timePerLessonPlan: "30-60 mins",
+    otherTimePerLessonPlan: "",
+    timePerLessonPlanOther: "",
+    resourcesUsed: ["Textbooks"],
+    otherResourceUsed: "",
+    resourcesUsedOther: "",
+    timeForAssessments: "10-20 mins",
+    otherTimeForAssessments: "",
+    timeForAssessmentsOther: "",
+    questionBalance: ["Bloom's taxonomy"],
+    otherQuestionBalance: "",
+    questionBalanceOther: "",
+    otherNotes: "Test comment",
+  };
+
+  describe("validateSubmitSurvey", () => {
+    it("should pass validation with valid survey data", () => {
+      mockReq.body = { ...validSurveyData };
+
+      validateSubmitSurvey(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect(mockRes.status).not.toHaveBeenCalled();
+    });
+
+    it("should fail when plans is missing", () => {
+      const { plans, ...dataWithoutPlans } = validSurveyData;
+      mockReq.body = dataWithoutPlans;
+
+      validateSubmitSurvey(mockReq, mockRes, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it("should fail when plans array is empty", () => {
+      mockReq.body = {
+        ...validSurveyData,
+        plans: [],
+      };
+
+      validateSubmitSurvey(mockReq, mockRes, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it("should fail when weeklyLessonPlans is missing", () => {
+      const { weeklyLessonPlans, ...dataWithoutPlans } = validSurveyData;
+      mockReq.body = dataWithoutPlans;
+
+      validateSubmitSurvey(mockReq, mockRes, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("validateRemindLater", () => {
+    it("should pass validation with empty body", () => {
+      mockReq.body = {};
+
+      validateRemindLater(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect(mockRes.status).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/shiksha-website/shiksha-backend/config/constants.js
+++ b/shiksha-website/shiksha-backend/config/constants.js
@@ -5,6 +5,8 @@ let MESSAGES = {
 
 const CHAT_LIMIT = 20;
 
-const REGENERATION_LIMIT = 3
+const REGENERATION_LIMIT = 3;
 
-module.exports = { MESSAGES, CHAT_LIMIT,REGENERATION_LIMIT };
+const MAX_REMIND_LATER = parseInt(process.env.MAX_REMIND_LATER, 10) || 2;
+
+module.exports = { MESSAGES, CHAT_LIMIT, REGENERATION_LIMIT, MAX_REMIND_LATER };

--- a/shiksha-website/shiksha-backend/controllers/baselineSurvey.controller.js
+++ b/shiksha-website/shiksha-backend/controllers/baselineSurvey.controller.js
@@ -30,7 +30,7 @@ class BaselineSurveyController {
       if (!userId) return res.status(401).json(formatResponse(false, 'Unauthorized', null));
 
       const result = await baselineSurveyManager.submitSurvey(userId, req.body);
-      const status = result.success ? 200 : (result.message?.includes('Already submitted') ? 409 : 400);
+      const status = result.success ? 200 : (result.code === 'ALREADY_SUBMITTED' ? 409 : 400);
       return res.status(status).json(result);
     } catch (err) {
       logger.error('Error in submitSurvey', {

--- a/shiksha-website/shiksha-backend/controllers/baselineSurvey.controller.js
+++ b/shiksha-website/shiksha-backend/controllers/baselineSurvey.controller.js
@@ -23,7 +23,7 @@ class BaselineSurveyController {
       if (!userId) return res.status(401).json(formatResponse(false, 'Unauthorized', null));
 
       const result = await baselineSurveyManager.submitSurvey(userId, req.body);
-      const status = result.success ? 200 : (result.message === 'Already submitted' ? 409 : 400);
+      const status = result.success ? 200 : (result.message?.includes('Already submitted') ? 409 : 400);
       return res.status(status).json(result);
     } catch (err) {
       console.error('BaselineSurveyController.submitSurvey', err);
@@ -33,6 +33,7 @@ class BaselineSurveyController {
       return res.status(500).json(formatResponse(false, 'Server error', null));
     }
   }
+  
 
   // PATCH /api/baseline-surveys/remind-later
   async remindLater(req, res) {

--- a/shiksha-website/shiksha-backend/controllers/baselineSurvey.controller.js
+++ b/shiksha-website/shiksha-backend/controllers/baselineSurvey.controller.js
@@ -1,50 +1,68 @@
 const baselineSurveyManager = require('../managers/baselineSurvey.manager');
 const formatResponse = require('../helper/response');
+const logger = require('../config/loggers');
 
 class BaselineSurveyController {
   // GET /api/baseline-surveys/check
   async checkIfCompleted(req, res) {
+    const userId = req.user?._id;
     try {
-      const userId = req.user?._id;
       if (!userId) return res.status(401).json(formatResponse(false, 'Unauthorized', null));
 
       const result = await baselineSurveyManager.checkCompleted(userId);
       return res.status(result.success ? 200 : 400).json(result);
     } catch (err) {
-      console.error('BaselineSurveyController.checkIfCompleted', err);
+      logger.error('Error in checkIfCompleted', {
+        functionName: 'checkIfCompleted',
+        userId,
+        route: req.originalUrl,
+        message: err.message,
+        stack: err.stack,
+      });
       return res.status(500).json(formatResponse(false, 'Server error', null));
     }
   }
 
   // POST /api/baseline-surveys
   async submitSurvey(req, res) {
+    const userId = req.user?._id;
     try {
-      const userId = req.user?._id;
       if (!userId) return res.status(401).json(formatResponse(false, 'Unauthorized', null));
 
       const result = await baselineSurveyManager.submitSurvey(userId, req.body);
       const status = result.success ? 200 : (result.message?.includes('Already submitted') ? 409 : 400);
       return res.status(status).json(result);
     } catch (err) {
-      console.error('BaselineSurveyController.submitSurvey', err);
+      logger.error('Error in submitSurvey', {
+        functionName: 'submitSurvey',
+        userId,
+        route: req.originalUrl,
+        message: err.message,
+        stack: err.stack,
+      });
       if (err?.code === 11000) {
         return res.status(409).json(formatResponse(false, 'Already submitted', null));
       }
       return res.status(500).json(formatResponse(false, 'Server error', null));
     }
   }
-  
 
   // PATCH /api/baseline-surveys/remind-later
   async remindLater(req, res) {
+    const userId = req.user?._id;
     try {
-      const userId = req.user?._id;
       if (!userId) return res.status(401).json(formatResponse(false, 'Unauthorized', null));
 
       const result = await baselineSurveyManager.incrementRemindLater(userId);
       return res.status(result.success ? 200 : 400).json(result);
     } catch (err) {
-      console.error('BaselineSurveyController.remindLater', err);
+      logger.error('Error in remindLater', {
+        functionName: 'remindLater',
+        userId,
+        route: req.originalUrl,
+        message: err.message,
+        stack: err.stack,
+      });
       return res.status(500).json(formatResponse(false, 'Server error', null));
     }
   }

--- a/shiksha-website/shiksha-backend/controllers/baselineSurvey.controller.js
+++ b/shiksha-website/shiksha-backend/controllers/baselineSurvey.controller.js
@@ -1,5 +1,5 @@
 const baselineSurveyManager = require('../managers/baselineSurvey.manager');
-const formatResponse = require('../helper/response'); // neutral alias
+const formatResponse = require('../helper/response');
 
 class BaselineSurveyController {
   // GET /api/baseline-surveys/check
@@ -23,13 +23,27 @@ class BaselineSurveyController {
       if (!userId) return res.status(401).json(formatResponse(false, 'Unauthorized', null));
 
       const result = await baselineSurveyManager.submitSurvey(userId, req.body);
-      const status = result.success ? 200 : (result.message === 'Already submitted for this academic year' ? 409 : 400);
+      const status = result.success ? 200 : (result.message === 'Already submitted' ? 409 : 400);
       return res.status(status).json(result);
     } catch (err) {
       console.error('BaselineSurveyController.submitSurvey', err);
       if (err?.code === 11000) {
         return res.status(409).json(formatResponse(false, 'Already submitted', null));
       }
+      return res.status(500).json(formatResponse(false, 'Server error', null));
+    }
+  }
+
+  // PATCH /api/baseline-surveys/remind-later
+  async remindLater(req, res) {
+    try {
+      const userId = req.user?._id;
+      if (!userId) return res.status(401).json(formatResponse(false, 'Unauthorized', null));
+
+      const result = await baselineSurveyManager.incrementRemindLater(userId);
+      return res.status(result.success ? 200 : 400).json(result);
+    } catch (err) {
+      console.error('BaselineSurveyController.remindLater', err);
       return res.status(500).json(formatResponse(false, 'Server error', null));
     }
   }

--- a/shiksha-website/shiksha-backend/dao/baselineSurvey.dao.js
+++ b/shiksha-website/shiksha-backend/dao/baselineSurvey.dao.js
@@ -1,7 +1,6 @@
 const BaseDao = require('./base.dao');
 const BaselineSurvey = require("../models/baselineSurvey.model");
 
-
 class BaselineSurveyDao extends BaseDao {
   constructor() {
     super(BaselineSurvey);
@@ -9,15 +8,24 @@ class BaselineSurveyDao extends BaseDao {
   }
 
   async existsByUser(userId, academicYear) {
+    if (!academicYear) {
+      throw new Error('Academic year is required');
+    }
     const exists = await this.model.exists({ userId, academicYear });
     return !!exists;
   }
 
   async findByUser(userId, academicYear) {
+    if (!academicYear) {
+      throw new Error('Academic year is required');
+    }
     return this.model.findOne({ userId, academicYear }).lean();
   }
 
   async createSurvey(payload, session = null) {
+    if (!payload.academicYear) {
+      throw new Error('Academic year is required in payload');
+    }
     return this.model.create([payload], { session }).then(([doc]) => doc);
   }
 }

--- a/shiksha-website/shiksha-backend/dao/baselineSurveyReminder.dao.js
+++ b/shiksha-website/shiksha-backend/dao/baselineSurveyReminder.dao.js
@@ -1,0 +1,37 @@
+const BaseDao = require('./base.dao');
+const BaselineSurveyReminder = require('../models/baselineSurveyReminder.model');
+
+class BaselineSurveyReminderDao extends BaseDao {
+  constructor() {
+    super(BaselineSurveyReminder);
+  }
+
+  /**
+   * Get the current remind-later count for a user in a given academic year.
+   * Returns 0 if no record exists.
+   */
+  async getCount(userId, academicYear) {
+    const rec = await this.Model.findOne({ userId, academicYear }).lean();
+    return rec ? rec.remindLaterCount : 0;
+  }
+
+  /**
+   * Atomically increment the remind-later count.
+   * Creates the record if it doesn't exist (upsert).
+   * @param {string} userId
+   * @param {number} academicYear
+   * @param {object|null} session - optional Mongoose session for transactions
+   * @returns {object} updated document
+   */
+  async increment(userId, academicYear, session = null) {
+    const opts = { upsert: true, new: true };
+    if (session) opts.session = session;
+    return this.Model.findOneAndUpdate(
+      { userId, academicYear },
+      { $inc: { remindLaterCount: 1 } },
+      opts
+    );
+  }
+}
+
+module.exports = BaselineSurveyReminderDao;

--- a/shiksha-website/shiksha-backend/helper/response.js
+++ b/shiksha-website/shiksha-backend/helper/response.js
@@ -1,9 +1,7 @@
-const formatApiReponse = (success, message, data) => {
-	return {
-		success,
-		message,
-		data,
-	};
+const formatApiReponse = (success, message, data, code) => {
+	const res = { success, message, data };
+	if (code) res.code = code;
+	return res;
 };
 
 module.exports = formatApiReponse;

--- a/shiksha-website/shiksha-backend/managers/baselineSurvey.manager.js
+++ b/shiksha-website/shiksha-backend/managers/baselineSurvey.manager.js
@@ -2,48 +2,49 @@
 const BaseManager = require('./base.manager');
 const formatApiResponse = require('../helper/response');
 const BaselineSurveyDao = require('../dao/baselineSurvey.dao');
-const BaselineSurveyReminder = require('../models/baselineSurveyReminder.model');
+const BaselineSurveyReminderDao = require('../dao/baselineSurveyReminder.dao');
+const { getAcademicYear } = require('../helper/academic.year.helper');
+const { MAX_REMIND_LATER } = require('../config/constants');
+const logger = require('../config/loggers');
 
-const MAX_REMIND_LATER = 3;
+/**
+ * Helper: if the array contains 'Other' and there is a corresponding
+ * text value, replace the 'Other' entry with 'Other: <text>'.
+ */
+const mergeOthers = (arr, otherText) => {
+  if (!Array.isArray(arr)) return [];
+  if (!otherText) return arr;
+  return arr.map(v => (v === 'Other' ? `Other: ${otherText.trim()}` : v));
+};
+
+/**
+ * Helper: for single-select radio fields that support an 'Other' option,
+ * replace the value with the free-text entry when selected.
+ */
+const resolveOther = (value, otherText) =>
+  value === 'Other' && otherText ? otherText.trim() : value;
 
 class BaselineSurveyManager extends BaseManager {
   constructor() {
     const dao = new BaselineSurveyDao();
     super(dao);
     this.dao = dao;
+    this.reminderDao = new BaselineSurveyReminderDao();
   }
 
   /**
-   * Calculate Academic Year.
-   * Academic Year X starts June 1, Year X and ends March 31, Year X+1.
+   * Get the remind-later count for a user.
+   * DB errors propagate to the caller — they must NOT be swallowed.
    */
-  getAcademicYearInfo() {
-    const now = new Date();
-    const month = now.getMonth(); // 0-11. June is 5, March is 2.
-    const year = now.getFullYear();
-
-    if (month >= 5) { // June onwards
-      return year;
-    } else {
-      return year - 1;
-    }
-  }
-
   async getRemindLaterCount(userId, academicYear) {
-    try {
-      const rec = await BaselineSurveyReminder.findOne({ userId, academicYear }).lean();
-      return rec ? rec.remindLaterCount : 0;
-    } catch (err) {
-      console.error('BaselineSurveyManager.getRemindLaterCount', err);
-      return 0;
-    }
+    return this.reminderDao.getCount(userId, academicYear);
   }
 
   async checkCompleted(userId) {
     try {
       if (!userId) return formatApiResponse(false, 'Missing userId', null);
 
-      const academicYear = this.getAcademicYearInfo();
+      const academicYear = getAcademicYear();
       const exists = await this.dao.existsByUser(userId, academicYear);
       const remindLaterCount = await this.getRemindLaterCount(userId, academicYear);
 
@@ -52,30 +53,48 @@ class BaselineSurveyManager extends BaseManager {
         academicYear,
         remindLaterCount,
         isMandatory: remindLaterCount >= MAX_REMIND_LATER,
+        maxReminders: MAX_REMIND_LATER,
       });
     } catch (err) {
-      console.error('BaselineSurveyManager.checkCompleted', err);
+      logger.error('checkCompleted failed', { functionName: 'checkCompleted', userId, message: err.message, stack: err.stack });
       return formatApiResponse(false, 'Server error', null);
     }
   }
 
-  async incrementRemindLater(userId) {
+  async incrementRemindLater(userId, session = null) {
     try {
       if (!userId) return formatApiResponse(false, 'Missing userId', null);
 
-      const academicYear = this.getAcademicYearInfo();
-      const rec = await BaselineSurveyReminder.findOneAndUpdate(
-        { userId, academicYear },
-        { $inc: { remindLaterCount: 1 } },
-        { upsert: true, new: true }
-      );
+      const academicYear = getAcademicYear();
+
+      // Guard: do not mutate reminder records for users who already submitted
+      const alreadyCompleted = await this.dao.existsByUser(userId, academicYear);
+      if (alreadyCompleted) {
+        const remindLaterCount = await this.getRemindLaterCount(userId, academicYear);
+        return formatApiResponse(true, 'Survey already completed', {
+          remindLaterCount,
+          isMandatory: remindLaterCount >= MAX_REMIND_LATER,
+          completed: true,
+        });
+      }
+
+      // Ceiling: do not increment past the maximum
+      const currentCount = await this.getRemindLaterCount(userId, academicYear);
+      if (currentCount >= MAX_REMIND_LATER) {
+        return formatApiResponse(true, 'Maximum reminders reached', {
+          remindLaterCount: currentCount,
+          isMandatory: true,
+        });
+      }
+
+      const rec = await this.reminderDao.increment(userId, academicYear, session);
 
       return formatApiResponse(true, 'Remind later recorded', {
         remindLaterCount: rec.remindLaterCount,
         isMandatory: rec.remindLaterCount >= MAX_REMIND_LATER,
       });
     } catch (err) {
-      console.error('BaselineSurveyManager.incrementRemindLater', err);
+      logger.error('incrementRemindLater failed', { functionName: 'incrementRemindLater', userId, message: err.message, stack: err.stack });
       return formatApiResponse(false, 'Server error', null);
     }
   }
@@ -84,26 +103,9 @@ class BaselineSurveyManager extends BaseManager {
     try {
       if (!userId) return formatApiResponse(false, 'Missing userId', null);
 
-      const academicYear = this.getAcademicYearInfo();
+      const academicYear = getAcademicYear();
       const already = await this.dao.findByUser(userId, academicYear);
-      if (already) return formatApiResponse(false, 'Already submitted for this academic year', null);
-
-      /**
-       * Helper: if the array contains 'Others' and there is a corresponding
-       * text value, replace the 'Others' entry with 'Others: <text>'.
-       */
-      const mergeOthers = (arr, otherText) => {
-        if (!Array.isArray(arr)) return [];
-        if (!otherText) return arr;
-        return arr.map(v => (v === 'Other' ? `Other: ${otherText.trim()}` : v));
-      };
-
-      /**
-       * Helper: for single-select radio fields that support an 'Others' option,
-       * replace the value with the free-text entry when selected.
-       */
-      const resolveOther = (value, otherText) =>
-        value === 'Other' && otherText ? otherText.trim() : value;
+      if (already) return formatApiResponse(false, 'Already submitted for this academic year', null, 'ALREADY_SUBMITTED');
 
       // ---- Q1: plans (multi-select) ----
       const plans = mergeOthers(body.plans, body.plansOther);
@@ -161,9 +163,9 @@ class BaselineSurveyManager extends BaseManager {
       const doc = await this.dao.createSurvey(payload, session);
       return formatApiResponse(true, 'Survey submitted', doc);
     } catch (err) {
-      console.error('BaselineSurveyManager.submitSurvey', err);
+      logger.error('submitSurvey failed', { functionName: 'submitSurvey', userId, message: err.message, stack: err.stack });
       if (err && err.code === 11000) {
-        return formatApiResponse(false, 'Already submitted for this academic year', null);
+        return formatApiResponse(false, 'Already submitted for this academic year', null, 'ALREADY_SUBMITTED');
       }
       return formatApiResponse(false, 'Server error', null);
     }

--- a/shiksha-website/shiksha-backend/managers/baselineSurvey.manager.js
+++ b/shiksha-website/shiksha-backend/managers/baselineSurvey.manager.js
@@ -1,91 +1,145 @@
 
-
 const BaseManager = require('./base.manager');
 const formatApiResponse = require('../helper/response');
 const BaselineSurveyDao = require('../dao/baselineSurvey.dao');
-const { getAcademicYear } = require('../helper/academic.year.helper');
+const BaselineSurveyReminder = require('../models/baselineSurveyReminder.model');
+
+const MAX_REMIND_LATER = 2;
 
 class BaselineSurveyManager extends BaseManager {
   constructor() {
     const dao = new BaselineSurveyDao();
     super(dao);
     this.dao = dao;
-    this.baselineSurvey = process.env.BASELINE_SURVEY === 'true';
+  }
+
+  /**
+   * Calculate Academic Year.
+   * Academic Year X starts June 1, Year X and ends March 31, Year X+1.
+   */
+  getAcademicYearInfo() {
+    const now = new Date();
+    const month = now.getMonth(); // 0-11. June is 5, March is 2.
+    const year = now.getFullYear();
+
+    if (month >= 5) { // June onwards
+      return year;
+    } else {
+      return year - 1;
+    }
+  }
+
+  async getRemindLaterCount(userId) {
+    try {
+      const rec = await BaselineSurveyReminder.findOne({ userId }).lean();
+      return rec ? rec.remindLaterCount : 0;
+    } catch (err) {
+      console.error('BaselineSurveyManager.getRemindLaterCount', err);
+      return 0;
+    }
   }
 
   async checkCompleted(userId) {
     try {
       if (!userId) return formatApiResponse(false, 'Missing userId', null);
-      if (!this.baselineSurvey) return formatApiResponse(true, 'OK', { completed: true });
-      const academicYear = getAcademicYear();
+
+      const academicYear = this.getAcademicYearInfo();
       const exists = await this.dao.existsByUser(userId, academicYear);
-      return formatApiResponse(true, 'OK', { completed: !!exists, academicYear });
+      const remindLaterCount = await this.getRemindLaterCount(userId);
+
+      return formatApiResponse(true, 'OK', {
+        completed: !!exists,
+        academicYear,
+        remindLaterCount,
+        isMandatory: remindLaterCount >= MAX_REMIND_LATER,
+      });
     } catch (err) {
       console.error('BaselineSurveyManager.checkCompleted', err);
       return formatApiResponse(false, 'Server error', null);
     }
   }
 
-  async submitSurvey(userId, body, session = null) {
+  async incrementRemindLater(userId) {
     try {
-      if (!this.baselineSurvey) return formatApiResponse(false, 'Survey is disabled', null);
       if (!userId) return formatApiResponse(false, 'Missing userId', null);
 
-      const academicYear = getAcademicYear();
+      const rec = await BaselineSurveyReminder.findOneAndUpdate(
+        { userId },
+        { $inc: { remindLaterCount: 1 } },
+        { upsert: true, new: true }
+      );
+
+      return formatApiResponse(true, 'Remind later recorded', {
+        remindLaterCount: rec.remindLaterCount,
+        isMandatory: rec.remindLaterCount >= MAX_REMIND_LATER,
+      });
+    } catch (err) {
+      console.error('BaselineSurveyManager.incrementRemindLater', err);
+      return formatApiResponse(false, 'Server error', null);
+    }
+  }
+
+  async submitSurvey(userId, body, session = null) {
+    try {
+      if (!userId) return formatApiResponse(false, 'Missing userId', null);
+
+      const academicYear = this.getAcademicYearInfo();
       const already = await this.dao.findByUser(userId, academicYear);
       if (already) return formatApiResponse(false, 'Already submitted for this academic year', null);
 
-      // ---- NORMALIZE ARRAYS ----
+      // ---- Q1: plans (multi-select) ----
       const plans = Array.isArray(body.plans) ? body.plans : [];
+      const plansOther = (body.plansOther || '').trim();
+
+      // ---- Q2: devices (multi-select) ----
       const devices = Array.isArray(body.devices) ? body.devices : [];
-      let lessonPlanComponents = Array.isArray(body.lessonPlanComponents)
-        ? body.lessonPlanComponents
-        : [];
-      let resourcesUsed = Array.isArray(body.resourcesUsed) ? body.resourcesUsed : [];
+      const devicesOther = (body.devicesOther || '').trim();
 
-      const otherLessonPlanComponent = (body.otherLessonPlanComponent || '').trim();
-      const otherResourceUsed = (body.otherResourceUsed || '').trim();
+      // ---- Q3: weeklyLessonPlans (single) ----
+      const weeklyLessonPlans = body.weeklyLessonPlans || '';
 
-      // If user typed "Others" for components, store it as "Others: <text>"
-      if (otherLessonPlanComponent) {
-        // remove bare "Others" from array if present
-        lessonPlanComponents = lessonPlanComponents.filter(v => v !== 'Others');
-        lessonPlanComponents.push(`Others: ${otherLessonPlanComponent}`);
-      }
+      // ---- Q4: lessonPlanComponents (multi-select) ----
+      const lessonPlanComponents = Array.isArray(body.lessonPlanComponents) ? body.lessonPlanComponents : [];
+      const lessonPlanComponentsOther = (body.lessonPlanComponentsOther || '').trim();
 
-      // If user typed "Others" for resources, store it as "Others: <text>"
-      if (otherResourceUsed) {
-        resourcesUsed = resourcesUsed.filter(v => v !== 'Others');
-        resourcesUsed.push(`Others: ${otherResourceUsed}`);
-      }
+      // ---- Q5: timePerLessonPlan (radio) ----
+      const timePerLessonPlan = body.timePerLessonPlan || '';
+      const timePerLessonPlanOther = (body.timePerLessonPlanOther || '').trim();
 
-      // ---- NORMALIZE TIME FIELDS ----
-      let timePerLessonPlan = body.timePerLessonPlan || '';
-      let timeForAssessments = body.timeForAssessments || '';
+      // ---- Q6: resourcesUsed (multi-select) ----
+      const resourcesUsed = Array.isArray(body.resourcesUsed) ? body.resourcesUsed : [];
+      const resourcesUsedOther = (body.resourcesUsedOther || '').trim();
 
-      const otherTimePerLessonPlan = (body.otherTimePerLessonPlan || '').trim();
-      const otherTimeForAssessments = (body.otherTimeForAssessments || '').trim();
+      // ---- Q7: timeForAssessments (radio) ----
+      const timeForAssessments = body.timeForAssessments || '';
+      const timeForAssessmentsOther = (body.timeForAssessmentsOther || '').trim();
 
-      // If dropdown value is "Others" and text is given, replace it with the text
-      if (timePerLessonPlan === 'Others' && otherTimePerLessonPlan) {
-        timePerLessonPlan = otherTimePerLessonPlan;
-      }
+      // ---- Q8: questionBalance (multi-select checkboxes) ----
+      const questionBalance = Array.isArray(body.questionBalance) ? body.questionBalance : [];
+      const questionBalanceOther = (body.questionBalanceOther || '').trim();
 
-      if (timeForAssessments === 'Others' && otherTimeForAssessments) {
-        timeForAssessments = otherTimeForAssessments;
-      }
+      // ---- Q9: additional comments ----
+      const otherNotes = body.otherNotes || '';
 
       const payload = {
         userId,
         academicYear,
         plans,
+        plansOther,
         devices,
-        weeklyLessonPlans: body.weeklyLessonPlans || '',
+        devicesOther,
+        weeklyLessonPlans,
         lessonPlanComponents,
+        lessonPlanComponentsOther,
         timePerLessonPlan,
+        timePerLessonPlanOther,
         resourcesUsed,
+        resourcesUsedOther,
         timeForAssessments,
-        otherNotes: body.otherNotes || '',
+        timeForAssessmentsOther,
+        questionBalance,
+        questionBalanceOther,
+        otherNotes,
       };
 
       const doc = await this.dao.createSurvey(payload, session);

--- a/shiksha-website/shiksha-backend/managers/baselineSurvey.manager.js
+++ b/shiksha-website/shiksha-backend/managers/baselineSurvey.manager.js
@@ -4,7 +4,7 @@ const formatApiResponse = require('../helper/response');
 const BaselineSurveyDao = require('../dao/baselineSurvey.dao');
 const BaselineSurveyReminder = require('../models/baselineSurveyReminder.model');
 
-const MAX_REMIND_LATER = 2;
+const MAX_REMIND_LATER = 3;
 
 class BaselineSurveyManager extends BaseManager {
   constructor() {
@@ -29,9 +29,9 @@ class BaselineSurveyManager extends BaseManager {
     }
   }
 
-  async getRemindLaterCount(userId) {
+  async getRemindLaterCount(userId, academicYear) {
     try {
-      const rec = await BaselineSurveyReminder.findOne({ userId }).lean();
+      const rec = await BaselineSurveyReminder.findOne({ userId, academicYear }).lean();
       return rec ? rec.remindLaterCount : 0;
     } catch (err) {
       console.error('BaselineSurveyManager.getRemindLaterCount', err);
@@ -45,7 +45,7 @@ class BaselineSurveyManager extends BaseManager {
 
       const academicYear = this.getAcademicYearInfo();
       const exists = await this.dao.existsByUser(userId, academicYear);
-      const remindLaterCount = await this.getRemindLaterCount(userId);
+      const remindLaterCount = await this.getRemindLaterCount(userId, academicYear);
 
       return formatApiResponse(true, 'OK', {
         completed: !!exists,
@@ -63,8 +63,9 @@ class BaselineSurveyManager extends BaseManager {
     try {
       if (!userId) return formatApiResponse(false, 'Missing userId', null);
 
+      const academicYear = this.getAcademicYearInfo();
       const rec = await BaselineSurveyReminder.findOneAndUpdate(
-        { userId },
+        { userId, academicYear },
         { $inc: { remindLaterCount: 1 } },
         { upsert: true, new: true }
       );
@@ -94,7 +95,7 @@ class BaselineSurveyManager extends BaseManager {
       const mergeOthers = (arr, otherText) => {
         if (!Array.isArray(arr)) return [];
         if (!otherText) return arr;
-        return arr.map(v => (v === 'Others' ? `Others: ${otherText.trim()}` : v));
+        return arr.map(v => (v === 'Other' ? `Other: ${otherText.trim()}` : v));
       };
 
       /**
@@ -102,7 +103,7 @@ class BaselineSurveyManager extends BaseManager {
        * replace the value with the free-text entry when selected.
        */
       const resolveOther = (value, otherText) =>
-        value === 'Others' && otherText ? otherText.trim() : value;
+        value === 'Other' && otherText ? otherText.trim() : value;
 
       // ---- Q1: plans (multi-select) ----
       const plans = mergeOthers(body.plans, body.plansOther);

--- a/shiksha-website/shiksha-backend/managers/baselineSurvey.manager.js
+++ b/shiksha-website/shiksha-backend/managers/baselineSurvey.manager.js
@@ -87,36 +87,58 @@ class BaselineSurveyManager extends BaseManager {
       const already = await this.dao.findByUser(userId, academicYear);
       if (already) return formatApiResponse(false, 'Already submitted for this academic year', null);
 
+      /**
+       * Helper: if the array contains 'Others' and there is a corresponding
+       * text value, replace the 'Others' entry with 'Others: <text>'.
+       */
+      const mergeOthers = (arr, otherText) => {
+        if (!Array.isArray(arr)) return [];
+        if (!otherText) return arr;
+        return arr.map(v => (v === 'Others' ? `Others: ${otherText.trim()}` : v));
+      };
+
+      /**
+       * Helper: for single-select radio fields that support an 'Others' option,
+       * replace the value with the free-text entry when selected.
+       */
+      const resolveOther = (value, otherText) =>
+        value === 'Others' && otherText ? otherText.trim() : value;
+
       // ---- Q1: plans (multi-select) ----
-      const plans = Array.isArray(body.plans) ? body.plans : [];
-      const plansOther = (body.plansOther || '').trim();
+      const plans = mergeOthers(body.plans, body.plansOther);
 
       // ---- Q2: devices (multi-select) ----
-      const devices = Array.isArray(body.devices) ? body.devices : [];
-      const devicesOther = (body.devicesOther || '').trim();
+      const devices = mergeOthers(body.devices, body.devicesOther);
 
       // ---- Q3: weeklyLessonPlans (single) ----
       const weeklyLessonPlans = body.weeklyLessonPlans || '';
 
       // ---- Q4: lessonPlanComponents (multi-select) ----
-      const lessonPlanComponents = Array.isArray(body.lessonPlanComponents) ? body.lessonPlanComponents : [];
-      const lessonPlanComponentsOther = (body.lessonPlanComponentsOther || '').trim();
+      const lessonPlanComponents = mergeOthers(
+        body.lessonPlanComponents,
+        body.otherLessonPlanComponent || body.lessonPlanComponentsOther
+      );
 
       // ---- Q5: timePerLessonPlan (radio) ----
-      const timePerLessonPlan = body.timePerLessonPlan || '';
-      const timePerLessonPlanOther = (body.timePerLessonPlanOther || '').trim();
+      const timePerLessonPlan = resolveOther(
+        body.timePerLessonPlan || '',
+        body.otherTimePerLessonPlan || body.timePerLessonPlanOther
+      );
 
       // ---- Q6: resourcesUsed (multi-select) ----
-      const resourcesUsed = Array.isArray(body.resourcesUsed) ? body.resourcesUsed : [];
-      const resourcesUsedOther = (body.resourcesUsedOther || '').trim();
+      const resourcesUsed = mergeOthers(
+        body.resourcesUsed,
+        body.otherResourceUsed || body.resourcesUsedOther
+      );
 
       // ---- Q7: timeForAssessments (radio) ----
-      const timeForAssessments = body.timeForAssessments || '';
-      const timeForAssessmentsOther = (body.timeForAssessmentsOther || '').trim();
+      const timeForAssessments = resolveOther(
+        body.timeForAssessments || '',
+        body.otherTimeForAssessments || body.timeForAssessmentsOther
+      );
 
-      // ---- Q8: questionBalance (multi-select checkboxes) ----
-      const questionBalance = Array.isArray(body.questionBalance) ? body.questionBalance : [];
-      const questionBalanceOther = (body.questionBalanceOther || '').trim();
+      // ---- Q8: questionBalance (multi-select) ----
+      const questionBalance = mergeOthers(body.questionBalance, body.questionBalanceOther);
 
       // ---- Q9: additional comments ----
       const otherNotes = body.otherNotes || '';
@@ -125,20 +147,13 @@ class BaselineSurveyManager extends BaseManager {
         userId,
         academicYear,
         plans,
-        plansOther,
         devices,
-        devicesOther,
         weeklyLessonPlans,
         lessonPlanComponents,
-        lessonPlanComponentsOther,
         timePerLessonPlan,
-        timePerLessonPlanOther,
         resourcesUsed,
-        resourcesUsedOther,
         timeForAssessments,
-        timeForAssessmentsOther,
         questionBalance,
-        questionBalanceOther,
         otherNotes,
       };
 

--- a/shiksha-website/shiksha-backend/models/baselineSurvey.model.js
+++ b/shiksha-website/shiksha-backend/models/baselineSurvey.model.js
@@ -4,24 +4,47 @@ const baselineSurveySchema = new mongoose.Schema(
   {
     userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true, index: true },
     academicYear: { type: Number, required: true, index: true },
-    // Q1..Q7
+
+    // Q1 – How do you currently prepare your lesson plans? (multi-select)
     plans: { type: [String], default: [] },
+    plansOther: { type: String, default: '' },
+
+    // Q2 – Which devices do you use while preparing lesson plans? (multi-select)
     devices: { type: [String], default: [] },
+    devicesOther: { type: String, default: '' },
+
+    // Q3 – How many lesson plans do you create in a week? (single select)
     weeklyLessonPlans: { type: String, default: '' },
+
+    // Q4 – Which components do you include in your lesson plans? (multi-select)
     lessonPlanComponents: { type: [String], default: [] },
+    lessonPlanComponentsOther: { type: String, default: '' },
+
+    // Q5 – How much time per lesson plan? (single radio)
     timePerLessonPlan: { type: String, default: '' },
+    timePerLessonPlanOther: { type: String, default: '' },
+
+    // Q6 – Which resources do you use? (multi-select)
     resourcesUsed: { type: [String], default: [] },
+    resourcesUsedOther: { type: String, default: '' },
+
+    // Q7 – How much time for one Formative Assessment? (single radio)
     timeForAssessments: { type: String, default: '' },
+    timeForAssessmentsOther: { type: String, default: '' },
+
+    // Q8 – How do you ensure question paper balance? (multi-select)
+    questionBalance: { type: [String], default: [] },
+    questionBalanceOther: { type: String, default: '' },
+
+    // Q9 – Additional comments
     otherNotes: { type: String, default: '' },
   },
   { timestamps: true }
 );
 
+// one survey per user per academic year
 baselineSurveySchema.index({ userId: 1, academicYear: 1 }, { unique: true });
 
-const BaselineSurvey = mongoose.model(
-  "BaselineSurvey",
-  baselineSurveySchema
-);
+const BaselineSurvey = mongoose.model('BaselineSurvey', baselineSurveySchema);
 
 module.exports = BaselineSurvey;

--- a/shiksha-website/shiksha-backend/models/baselineSurvey.model.js
+++ b/shiksha-website/shiksha-backend/models/baselineSurvey.model.js
@@ -6,35 +6,30 @@ const baselineSurveySchema = new mongoose.Schema(
     academicYear: { type: Number, required: true, index: true },
 
     // Q1 – How do you currently prepare your lesson plans? (multi-select)
+    // Values can include "Other: <custom text>" when the teacher selects Other
     plans: { type: [String], default: [] },
-    plansOther: { type: String, default: '' },
 
     // Q2 – Which devices do you use while preparing lesson plans? (multi-select)
     devices: { type: [String], default: [] },
-    devicesOther: { type: String, default: '' },
 
     // Q3 – How many lesson plans do you create in a week? (single select)
     weeklyLessonPlans: { type: String, default: '' },
 
     // Q4 – Which components do you include in your lesson plans? (multi-select)
     lessonPlanComponents: { type: [String], default: [] },
-    lessonPlanComponentsOther: { type: String, default: '' },
 
     // Q5 – How much time per lesson plan? (single radio)
+    // Value may be free-text when teacher picks Other
     timePerLessonPlan: { type: String, default: '' },
-    timePerLessonPlanOther: { type: String, default: '' },
 
     // Q6 – Which resources do you use? (multi-select)
     resourcesUsed: { type: [String], default: [] },
-    resourcesUsedOther: { type: String, default: '' },
 
     // Q7 – How much time for one Formative Assessment? (single radio)
     timeForAssessments: { type: String, default: '' },
-    timeForAssessmentsOther: { type: String, default: '' },
 
     // Q8 – How do you ensure question paper balance? (multi-select)
     questionBalance: { type: [String], default: [] },
-    questionBalanceOther: { type: String, default: '' },
 
     // Q9 – Additional comments
     otherNotes: { type: String, default: '' },

--- a/shiksha-website/shiksha-backend/models/baselineSurveyReminder.model.js
+++ b/shiksha-website/shiksha-backend/models/baselineSurveyReminder.model.js
@@ -2,11 +2,15 @@ const mongoose = require('mongoose');
 
 const baselineSurveyReminderSchema = new mongoose.Schema(
   {
-    userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true, unique: true, index: true },
+    userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+    academicYear: { type: Number, required: true },
     remindLaterCount: { type: Number, default: 0 },
   },
   { timestamps: true }
 );
+
+// One reminder config per user per academic year
+baselineSurveyReminderSchema.index({ userId: 1, academicYear: 1 }, { unique: true });
 
 const BaselineSurveyReminder = mongoose.model(
   'BaselineSurveyReminder',

--- a/shiksha-website/shiksha-backend/models/baselineSurveyReminder.model.js
+++ b/shiksha-website/shiksha-backend/models/baselineSurveyReminder.model.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+
+const baselineSurveyReminderSchema = new mongoose.Schema(
+  {
+    userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true, unique: true, index: true },
+    remindLaterCount: { type: Number, default: 0 },
+  },
+  { timestamps: true }
+);
+
+const BaselineSurveyReminder = mongoose.model(
+  'BaselineSurveyReminder',
+  baselineSurveyReminderSchema
+);
+
+module.exports = BaselineSurveyReminder;

--- a/shiksha-website/shiksha-backend/package-lock.json
+++ b/shiksha-website/shiksha-backend/package-lock.json
@@ -24,6 +24,7 @@
         "dotenv": "^16.4.5",
         "exceljs": "^4.4.0",
         "express": "^4.19.2",
+        "express-rate-limit": "^8.6.0",
         "express-useragent": "^1.0.15",
         "fs": "^0.0.1-security",
         "http-proxy-middleware": "^3.0.5",
@@ -6132,6 +6133,48 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/express-useragent": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/express-useragent/-/express-useragent-1.0.15.tgz",
@@ -7134,10 +7177,10 @@
       "dev": true
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "devOptional": true,
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }

--- a/shiksha-website/shiksha-backend/package.json
+++ b/shiksha-website/shiksha-backend/package.json
@@ -38,6 +38,7 @@
     "dotenv": "^16.4.5",
     "exceljs": "^4.4.0",
     "express": "^4.19.2",
+    "express-rate-limit": "^8.6.0",
     "express-useragent": "^1.0.15",
     "fs": "^0.0.1-security",
     "http-proxy-middleware": "^3.0.5",

--- a/shiksha-website/shiksha-backend/routes/baselineSurvey.routes.js
+++ b/shiksha-website/shiksha-backend/routes/baselineSurvey.routes.js
@@ -1,8 +1,20 @@
 const express = require('express');
 const router = express.Router();
+const rateLimit = require('express-rate-limit');
+const { ipKeyGenerator } = require('express-rate-limit');
 const asyncMiddleware = require('../middlewares/asyncMiddleware');
 const { isAuthenticated } = require('../middlewares/auth');
 const baselineController = require('../controllers/baselineSurvey.controller');
+
+// Per-user rate limit for the remind-later endpoint
+const remindLaterLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 5,
+  keyGenerator: (req) => req.user?._id?.toString() || ipKeyGenerator(req.ip),
+  message: { success: false, message: 'Too many requests, try again later' },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 router.get(
   '/baseline-surveys/check',
@@ -19,6 +31,7 @@ router.post(
 router.patch(
   '/baseline-surveys/remind-later',
   isAuthenticated,
+  remindLaterLimiter,
   asyncMiddleware(baselineController.remindLater.bind(baselineController))
 );
 

--- a/shiksha-website/shiksha-backend/routes/baselineSurvey.routes.js
+++ b/shiksha-website/shiksha-backend/routes/baselineSurvey.routes.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const router = express.Router();
 const rateLimit = require('express-rate-limit');
-const { ipKeyGenerator } = require('express-rate-limit');
 const asyncMiddleware = require('../middlewares/asyncMiddleware');
 const { isAuthenticated } = require('../middlewares/auth');
 const baselineController = require('../controllers/baselineSurvey.controller');
@@ -11,7 +10,7 @@ const { validateSubmitSurvey, validateRemindLater } = require('../validations/ba
 const remindLaterLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 5,
-  keyGenerator: (req) => req.user?._id?.toString() || ipKeyGenerator(req.ip),
+  keyGenerator: (req) => req.user._id.toString(),
   message: { success: false, message: 'Too many requests, try again later' },
   standardHeaders: true,
   legacyHeaders: false,

--- a/shiksha-website/shiksha-backend/routes/baselineSurvey.routes.js
+++ b/shiksha-website/shiksha-backend/routes/baselineSurvey.routes.js
@@ -5,6 +5,7 @@ const { ipKeyGenerator } = require('express-rate-limit');
 const asyncMiddleware = require('../middlewares/asyncMiddleware');
 const { isAuthenticated } = require('../middlewares/auth');
 const baselineController = require('../controllers/baselineSurvey.controller');
+const { validateSubmitSurvey, validateRemindLater } = require('../validations/baselineSurvey.validation');
 
 // Per-user rate limit for the remind-later endpoint
 const remindLaterLimiter = rateLimit({
@@ -25,6 +26,7 @@ router.get(
 router.post(
   '/baseline-surveys',
   isAuthenticated,
+  validateSubmitSurvey,
   asyncMiddleware(baselineController.submitSurvey.bind(baselineController))
 );
 
@@ -32,6 +34,7 @@ router.patch(
   '/baseline-surveys/remind-later',
   isAuthenticated,
   remindLaterLimiter,
+  validateRemindLater,
   asyncMiddleware(baselineController.remindLater.bind(baselineController))
 );
 

--- a/shiksha-website/shiksha-backend/routes/baselineSurvey.routes.js
+++ b/shiksha-website/shiksha-backend/routes/baselineSurvey.routes.js
@@ -16,4 +16,10 @@ router.post(
   asyncMiddleware(baselineController.submitSurvey.bind(baselineController))
 );
 
+router.patch(
+  '/baseline-surveys/remind-later',
+  isAuthenticated,
+  asyncMiddleware(baselineController.remindLater.bind(baselineController))
+);
+
 module.exports = router;

--- a/shiksha-website/shiksha-backend/validations/baselineSurvey.validation.js
+++ b/shiksha-website/shiksha-backend/validations/baselineSurvey.validation.js
@@ -1,0 +1,56 @@
+const Joi = require('joi');
+
+const submitSurveySchema = Joi.object({
+  plans: Joi.array().items(Joi.string()).min(1).required(),
+  plansOther: Joi.string().allow('').optional(),
+  devices: Joi.array().items(Joi.string()).min(1).required(),
+  devicesOther: Joi.string().allow('').optional(),
+  weeklyLessonPlans: Joi.string().required(),
+  lessonPlanComponents: Joi.array().items(Joi.string()).min(1).required(),
+  otherLessonPlanComponent: Joi.string().allow('').optional(),
+  lessonPlanComponentsOther: Joi.string().allow('').optional(),
+  timePerLessonPlan: Joi.string().required(),
+  otherTimePerLessonPlan: Joi.string().allow('').optional(),
+  timePerLessonPlanOther: Joi.string().allow('').optional(),
+  resourcesUsed: Joi.array().items(Joi.string()).min(1).required(),
+  otherResourceUsed: Joi.string().allow('').optional(),
+  resourcesUsedOther: Joi.string().allow('').optional(),
+  timeForAssessments: Joi.string().required(),
+  otherTimeForAssessments: Joi.string().allow('').optional(),
+  timeForAssessmentsOther: Joi.string().allow('').optional(),
+  questionBalance: Joi.array().items(Joi.string()).min(1).required(),
+  otherQuestionBalance: Joi.string().allow('').optional(),
+  questionBalanceOther: Joi.string().allow('').optional(),
+  otherNotes: Joi.string().allow('').optional(),
+});
+
+const remindLaterSchema = Joi.object({}).unknown(true); // allow any fields to avoid strict route checks
+
+const validateSubmitSurvey = (req, res, next) => {
+  const { error } = submitSurveySchema.validate(req.body, { abortEarly: false });
+  if (error) {
+    return res.status(400).json({
+      success: false,
+      data: false,
+      error: error.details.map((d) => d.message),
+    });
+  }
+  next();
+};
+
+const validateRemindLater = (req, res, next) => {
+  const { error } = remindLaterSchema.validate(req.body, { abortEarly: false });
+  if (error) {
+    return res.status(400).json({
+      success: false,
+      data: false,
+      error: error.details.map((d) => d.message),
+    });
+  }
+  next();
+};
+
+module.exports = {
+  validateSubmitSurvey,
+  validateRemindLater,
+};

--- a/shiksha-website/shiksha-frontend/src/app/app.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/app.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { firstValueFrom } from 'rxjs';
 
 import { SignInService } from './auth/sign-in.service';
 import { UtilityService } from './core/services/utility.service';
@@ -8,9 +7,6 @@ import { AuthorizationService } from './core/services/authorization.service';
 import { LoaderMessageService } from './core/services/loader-message.service';
 import { IdleService } from './shared/services/idle.service';
 import { IDLE_START_THRESHOLD, IDLE_WARNING_THRESHOLD } from './shared/utility/constant.util';
-
-import { BaselineSurveyService } from './core/services/baseline-survey.service';
-import { BaselineSurveyDialogService } from './core/services/baseline-survey-dialog.service';
 
 @Component({
   selector: 'app-root',
@@ -31,9 +27,7 @@ export class AppComponent implements OnInit, OnDestroy {
     private router: Router,
     private authorizationService: AuthorizationService,
     public loaderMessage: LoaderMessageService,
-    private idleService: IdleService,
-    private baselineSurveyService: BaselineSurveyService,
-    private baselineSurveyDialog: BaselineSurveyDialogService
+    private idleService: IdleService
   ) {}
 
   ngOnInit(): void {
@@ -63,26 +57,10 @@ export class AppComponent implements OnInit, OnDestroy {
 
           if (user) {
             localStorage.setItem('userData', JSON.stringify(user));
-
-            // Only teachers / end users should see baseline survey
-            if (this.isEndUser(user)) {
-              this.checkBaselineStatus();
-            }
           }
         },
         error: (err: any) => {
           this.utilityService.handleError(err);
-
-          // fallback: use stored data
-          const stored = localStorage.getItem('userData');
-          if (stored) {
-            try {
-              const u = JSON.parse(stored);
-              if (this.isEndUser(u)) {
-                this.checkBaselineStatus();
-              }
-            } catch {}
-          }
         }
       });
     }
@@ -90,37 +68,6 @@ export class AppComponent implements OnInit, OnDestroy {
     window.addEventListener('beforeunload', this.handleBeforeUnload.bind(this));
   }
 
-  // ------ Determine which roles should see survey ------
-  private isEndUser(user: any): boolean {
-    const roles: string[] = Array.isArray(user?.role)
-      ? user.role
-      : [user?.role].filter(Boolean);
-
-    const END_USER_ROLES = new Set(['teacher', 'user', 'end_user', 'librarian']);
-    const EXCLUDE = new Set(['manager', 'admin', 'super_admin']);
-
-    if (roles.some(r => EXCLUDE.has(String(r).toLowerCase()))) return false;
-    if (roles.some(r => END_USER_ROLES.has(String(r).toLowerCase()))) return true;
-
-    return false;
-  }
-
-  // ------ Check baseline survey completion ------
-  private async checkBaselineStatus(): Promise<void> {
-    try {
-      const response = await firstValueFrom(this.baselineSurveyService.checkCompleted());
-
-      if (response?.success && !response.data?.completed) {
-        const submitted = await this.baselineSurveyDialog.openSurvey();
-
-        if (submitted) {
-          this.utilityService.showSuccess('Thank you for completing the survey!');
-        }
-      }
-    } catch (error) {
-      console.error('Error checking baseline survey status:', error);
-    }
-  }
 
   // ------ User leaving tab/window ------
   handleBeforeUnload(event: BeforeUnloadEvent): void {

--- a/shiksha-website/shiksha-frontend/src/app/auth/sign-in/sign-in.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/auth/sign-in/sign-in.component.ts
@@ -12,9 +12,6 @@ import { TranslateService } from '@ngx-translate/core';
 import { SecureCookieService } from 'src/app/shared/services/cookie.service';
 import { applicationUsers } from 'src/app/shared/utility/enum.util';
 import { environment } from 'src/environments/environment';
-import { BaselineSurveyService } from 'src/app/core/services/baseline-survey.service';
-import { BaselineSurveyDialogService } from 'src/app/core/services/baseline-survey-dialog.service';
-import { firstValueFrom } from 'rxjs';
 
 @Component({
   selector: 'app-sign-in',
@@ -75,8 +72,6 @@ export class SignInComponent implements OnInit,AfterViewInit, OnDestroy {
     private sidebarService:SidebarService,
     private translateService: TranslateService,
     private secureCookieService:SecureCookieService,
-    private baselineSurveyService: BaselineSurveyService,
-    private baselineSurveyDialog: BaselineSurveyDialogService
   ) {}
 
   /**
@@ -104,26 +99,8 @@ export class SignInComponent implements OnInit,AfterViewInit, OnDestroy {
       this.router.navigate(['/profile']);
     } else if (isTeacherOnly) {
       this.router.navigate(['/home']);
-      // Reset session state and immediately trigger survey check on login
-      this.baselineSurveyService.resetSession();
-      this.triggerSurveyCheck();
     } else {
       this.router.navigate(['/dashboard']);
-    }
-  }
-
-  /** Checks the survey after login and shows the popup if pending */
-  private async triggerSurveyCheck(): Promise<void> {
-    try {
-      const resp = await firstValueFrom(this.baselineSurveyService.checkCompleted());
-      if (resp?.success && !resp?.data?.completed) {
-        void this.baselineSurveyDialog.openSurvey(
-          !!resp.data.isMandatory,
-          resp.data.remindLaterCount ?? 0
-        );
-      }
-    } catch {
-      // swallow errors — login flow should not be blocked
     }
   }
 

--- a/shiksha-website/shiksha-frontend/src/app/auth/sign-in/sign-in.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/auth/sign-in/sign-in.component.ts
@@ -12,6 +12,9 @@ import { TranslateService } from '@ngx-translate/core';
 import { SecureCookieService } from 'src/app/shared/services/cookie.service';
 import { applicationUsers } from 'src/app/shared/utility/enum.util';
 import { environment } from 'src/environments/environment';
+import { BaselineSurveyService } from 'src/app/core/services/baseline-survey.service';
+import { BaselineSurveyDialogService } from 'src/app/core/services/baseline-survey-dialog.service';
+import { firstValueFrom } from 'rxjs';
 
 @Component({
   selector: 'app-sign-in',
@@ -71,7 +74,9 @@ export class SignInComponent implements OnInit,AfterViewInit, OnDestroy {
     private authService:AuthorizationService,
     private sidebarService:SidebarService,
     private translateService: TranslateService,
-    private secureCookieService:SecureCookieService
+    private secureCookieService:SecureCookieService,
+    private baselineSurveyService: BaselineSurveyService,
+    private baselineSurveyDialog: BaselineSurveyDialogService
   ) {}
 
   /**
@@ -90,14 +95,35 @@ export class SignInComponent implements OnInit,AfterViewInit, OnDestroy {
 
   navigateAfterLogin(userData: any) {
     const roles = userData?.role || [];
-    const isTeacher = roles.includes('standard') || roles.includes('power');
+    const isTeacherOnly = (roles.includes('standard') || roles.includes('power'))
+      && !roles.includes('admin') && !roles.includes('manager')
+      && !roles.includes('super_admin') && !roles.includes('coordinator')
+      && !roles.includes('trainer');
 
-    if (isTeacher && !userData.isProfileCompleted) {
+    if (isTeacherOnly && !userData.isProfileCompleted) {
       this.router.navigate(['/profile']);
-    } else if (isTeacher) {
+    } else if (isTeacherOnly) {
       this.router.navigate(['/home']);
+      // Reset session state and immediately trigger survey check on login
+      this.baselineSurveyService.resetSession();
+      this.triggerSurveyCheck();
     } else {
       this.router.navigate(['/dashboard']);
+    }
+  }
+
+  /** Checks the survey after login and shows the popup if pending */
+  private async triggerSurveyCheck(): Promise<void> {
+    try {
+      const resp = await firstValueFrom(this.baselineSurveyService.checkCompleted());
+      if (resp?.success && !resp?.data?.completed) {
+        void this.baselineSurveyDialog.openSurvey(
+          !!resp.data.isMandatory,
+          resp.data.remindLaterCount ?? 0
+        );
+      }
+    } catch {
+      // swallow errors — login flow should not be blocked
     }
   }
 

--- a/shiksha-website/shiksha-frontend/src/app/auth/sign-in/sign-in.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/auth/sign-in/sign-in.component.ts
@@ -89,11 +89,7 @@ export class SignInComponent implements OnInit,AfterViewInit, OnDestroy {
   }
 
   navigateAfterLogin(userData: any) {
-    const roles = userData?.role || [];
-    const isTeacherOnly = (roles.includes('standard') || roles.includes('power'))
-      && !roles.includes('admin') && !roles.includes('manager')
-      && !roles.includes('super_admin') && !roles.includes('coordinator')
-      && !roles.includes('trainer');
+    const isTeacherOnly = this.authService.isTeacherOnly(userData);
 
     if (isTeacherOnly && !userData.isProfileCompleted) {
       this.router.navigate(['/profile']);

--- a/shiksha-website/shiksha-frontend/src/app/core/guards/baseline-survey.guard.ts
+++ b/shiksha-website/shiksha-frontend/src/app/core/guards/baseline-survey.guard.ts
@@ -39,8 +39,9 @@ export class BaselineSurveyGuard implements CanActivate {
     try {
       const resp = await firstValueFrom(this.survey.checkCompleted());
       const completed = !!resp?.data?.completed;
-      const remindLaterCount = resp?.data?.remindLaterCount ?? 0;
+      const remindLaterCount = resp?.data?.remindLaterCount;
       const isMandatory = !!resp?.data?.isMandatory;
+      const maxReminders = resp?.data?.maxReminders;
 
       // 3) Open dialog ONLY if API request succeeded AND survey is not completed
       if (resp?.success && !completed) {
@@ -49,7 +50,7 @@ export class BaselineSurveyGuard implements CanActivate {
           setTimeout(() => {
             this.zone.run(() => {
               // fire-and-forget so guard returns immediately
-              void this.dialog.openSurvey(isMandatory, remindLaterCount);
+              void this.dialog.openSurvey(isMandatory, remindLaterCount, maxReminders);
             });
           }, 0);
         });

--- a/shiksha-website/shiksha-frontend/src/app/core/guards/baseline-survey.guard.ts
+++ b/shiksha-website/shiksha-frontend/src/app/core/guards/baseline-survey.guard.ts
@@ -28,7 +28,7 @@ export class BaselineSurveyGuard implements CanActivate {
     }
 
     const user = this.getUser();
-    if (!this.isEndUser(user)) return true; // skip for managers/admins
+    if (!this.authz.isTeacherOnly(user)) return true; // skip for managers/admins/non-teachers
 
     // Skip if already dismissed/postponed in the current session
     if (this.survey.isDismissed()) {
@@ -48,9 +48,12 @@ export class BaselineSurveyGuard implements CanActivate {
         // Defer dialog open to next macrotask to avoid change detection race with navigation
         this.zone.runOutsideAngular(() => {
           setTimeout(() => {
-            this.zone.run(() => {
+            this.zone.run(async () => {
               // fire-and-forget so guard returns immediately
-              void this.dialog.openSurvey(isMandatory, remindLaterCount, maxReminders);
+              const res = await this.dialog.openSurvey(isMandatory, remindLaterCount, maxReminders);
+              if (res === 'remind') {
+                this.survey.setDismissed(true);
+              }
             });
           }, 0);
         });
@@ -59,7 +62,7 @@ export class BaselineSurveyGuard implements CanActivate {
       // swallow errors so routing isn't blocked
       console.error('[BaselineSurveyGuard] check/open failed', e);
     }
-
+ 
     return true;
   }
 
@@ -70,17 +73,5 @@ export class BaselineSurveyGuard implements CanActivate {
     } catch {
       return null;
     }
-  }
-
-  /** Treat everyone who is NOT an admin/manager as an end-user */
-  private isEndUser(user: any): boolean {
-    const roles: string[] = Array.isArray(user?.role) ? user.role : [user?.role].filter(Boolean);
-    if (!roles.length) return false;
-
-    const lower = roles.map(r => String(r).toLowerCase());
-    const EXCLUDE = new Set(['admin', 'manager', 'super_admin', 'coordinator', 'trainer']);
-
-    if (lower.some(r => EXCLUDE.has(r))) return false;
-    return true;
   }
 }

--- a/shiksha-website/shiksha-frontend/src/app/core/guards/baseline-survey.guard.ts
+++ b/shiksha-website/shiksha-frontend/src/app/core/guards/baseline-survey.guard.ts
@@ -30,19 +30,26 @@ export class BaselineSurveyGuard implements CanActivate {
     const user = this.getUser();
     if (!this.isEndUser(user)) return true; // skip for managers/admins
 
+    // Skip if already dismissed/postponed in the current session
+    if (this.survey.isDismissed()) {
+      return true;
+    }
+
     // 2) Check completion
     try {
       const resp = await firstValueFrom(this.survey.checkCompleted());
       const completed = !!resp?.data?.completed;
+      const remindLaterCount = resp?.data?.remindLaterCount ?? 0;
+      const isMandatory = !!resp?.data?.isMandatory;
 
-      // 3) Open dialog if not completed
-      if (!completed) {
+      // 3) Open dialog ONLY if API request succeeded AND survey is not completed
+      if (resp?.success && !completed) {
         // Defer dialog open to next macrotask to avoid change detection race with navigation
         this.zone.runOutsideAngular(() => {
           setTimeout(() => {
             this.zone.run(() => {
               // fire-and-forget so guard returns immediately
-              void this.dialog.openSurvey(true);
+              void this.dialog.openSurvey(isMandatory, remindLaterCount);
             });
           }, 0);
         });

--- a/shiksha-website/shiksha-frontend/src/app/core/services/authorization.service.ts
+++ b/shiksha-website/shiksha-frontend/src/app/core/services/authorization.service.ts
@@ -80,4 +80,19 @@ export class AuthorizationService {
     this.loggedIn.next(false);
     this.router.navigate(['/login']);
   }
+
+  /**
+   * Helper to identify if a user is a teacher only (end-user for surveys)
+   * i.e. has standard or power role, and does not have administrative/management roles
+   */
+  isTeacherOnly(user: any): boolean {
+    const roles: string[] = Array.isArray(user?.role) ? user.role : [user?.role].filter(Boolean);
+    if (!roles.length) return false;
+    const lower = roles.map(r => String(r).toLowerCase());
+    const hasTeacherRole = lower.some(r => r === 'standard' || r === 'power');
+    const hasExcludeRole = lower.some(r => {
+      return ['admin', 'manager', 'super_admin', 'coordinator', 'trainer'].includes(r);
+    });
+    return hasTeacherRole && !hasExcludeRole;
+  }
 }

--- a/shiksha-website/shiksha-frontend/src/app/core/services/authorization.service.ts
+++ b/shiksha-website/shiksha-frontend/src/app/core/services/authorization.service.ts
@@ -89,10 +89,6 @@ export class AuthorizationService {
     const roles: string[] = Array.isArray(user?.role) ? user.role : [user?.role].filter(Boolean);
     if (!roles.length) return false;
     const lower = roles.map(r => String(r).toLowerCase());
-    const hasTeacherRole = lower.some(r => r === 'standard' || r === 'power');
-    const hasExcludeRole = lower.some(r => {
-      return ['admin', 'manager', 'super_admin', 'coordinator', 'trainer'].includes(r);
-    });
-    return hasTeacherRole && !hasExcludeRole;
+    return lower.every(r => r === 'standard' || r === 'power');
   }
 }

--- a/shiksha-website/shiksha-frontend/src/app/core/services/baseline-survey-dialog.service.ts
+++ b/shiksha-website/shiksha-frontend/src/app/core/services/baseline-survey-dialog.service.ts
@@ -32,6 +32,7 @@ export class BaselineSurveyDialogService {
       width: '720px',
       maxWidth: '95vw',
       disableClose: true,
+      closeOnNavigation: false,
       autoFocus: true,
       data: { force, isMandatory: force, remindLaterCount, maxReminders }
     });

--- a/shiksha-website/shiksha-frontend/src/app/core/services/baseline-survey-dialog.service.ts
+++ b/shiksha-website/shiksha-frontend/src/app/core/services/baseline-survey-dialog.service.ts
@@ -13,9 +13,10 @@ export class BaselineSurveyDialogService {
    * Opens the baseline survey dialog.
    * @param force - if true, Remind Me Later button is hidden (mandatory)
    * @param remindLaterCount - current remind count passed into the dialog
+   * @param maxReminders - max allowed reminders (from API)
    * Returns true if submitted, 'remind' if reminded, false if closed otherwise.
    */
-  async openSurvey(force = false, remindLaterCount = 0): Promise<boolean> {
+  async openSurvey(force = false, remindLaterCount = 0, maxReminders = 3): Promise<boolean> {
     // Prevent stacking multiple instances of the baseline survey dialog
     const isOpen = this.dialog.openDialogs.some(
       (d) => d.componentInstance instanceof BaselineSurveyComponent
@@ -29,16 +30,18 @@ export class BaselineSurveyDialogService {
       maxWidth: '95vw',
       disableClose: true,
       autoFocus: true,
-      data: { force, isMandatory: force, remindLaterCount }
+      data: { force, isMandatory: force, remindLaterCount, maxReminders }
     });
 
     const result = await firstValueFrom(ref.afterClosed());
     if (result === true) {
       this.surveyService.setCompleted(true);
       return true;
-    } else {
+    } else if (result === 'remind') {
       this.surveyService.setDismissed(true);
       return false;
     }
+    // Unexpected close (error, null, etc.) — do NOT dismiss for session
+    return false;
   }
 }

--- a/shiksha-website/shiksha-frontend/src/app/core/services/baseline-survey-dialog.service.ts
+++ b/shiksha-website/shiksha-frontend/src/app/core/services/baseline-survey-dialog.service.ts
@@ -14,9 +14,12 @@ export class BaselineSurveyDialogService {
    * @param force - if true, Remind Me Later button is hidden (mandatory)
    * @param remindLaterCount - current remind count passed into the dialog
    * @param maxReminders - max allowed reminders (from API)
-   * Returns true if submitted, 'remind' if reminded, false if closed otherwise.
+   * @returns Promise resolving to:
+   * - `true` if survey submitted/completed
+   * - `'remind'` if user selected "Remind me later"
+   * - `false` if closed or failed to open otherwise
    */
-  async openSurvey(force = false, remindLaterCount = 0, maxReminders = 3): Promise<boolean> {
+  async openSurvey(force = false, remindLaterCount = 0, maxReminders = 3): Promise<boolean | 'remind'> {
     // Prevent stacking multiple instances of the baseline survey dialog
     const isOpen = this.dialog.openDialogs.some(
       (d) => d.componentInstance instanceof BaselineSurveyComponent
@@ -38,8 +41,7 @@ export class BaselineSurveyDialogService {
       this.surveyService.setCompleted(true);
       return true;
     } else if (result === 'remind') {
-      this.surveyService.setDismissed(true);
-      return false;
+      return 'remind';
     }
     // Unexpected close (error, null, etc.) — do NOT dismiss for session
     return false;

--- a/shiksha-website/shiksha-frontend/src/app/core/services/baseline-survey-dialog.service.ts
+++ b/shiksha-website/shiksha-frontend/src/app/core/services/baseline-survey-dialog.service.ts
@@ -2,36 +2,43 @@ import { Injectable, inject } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { firstValueFrom } from 'rxjs';
 import { BaselineSurveyComponent } from 'src/app/shared/components/baseline-survey/baseline-survey.component';
+import { BaselineSurveyService } from './baseline-survey.service';
 
 @Injectable({ providedIn: 'root' })
 export class BaselineSurveyDialogService {
   private dialog = inject(MatDialog);
+  private surveyService = inject(BaselineSurveyService);
 
-  private sessionKey(userId: string | number) {
-    const year = new Date().getFullYear();
-    return `baseline:shown:${userId}:${year}`;
-  }
-
-  /** Opens the survey dialog (blocking by default). Returns true if submitted. */
-  async openSurvey(force = true): Promise<boolean> {
-    let userId = '';
-    try {
-      const stored = localStorage.getItem('userData');
-      userId = stored ? JSON.parse(stored)?._id || '' : '';
-    } catch {}
-
-    const key = userId ? this.sessionKey(userId) : `baseline:shown:anon:${new Date().getFullYear()}`;
-    if (localStorage.getItem(key) === '1') return false;
+  /**
+   * Opens the baseline survey dialog.
+   * @param force - if true, Remind Me Later button is hidden (mandatory)
+   * @param remindLaterCount - current remind count passed into the dialog
+   * Returns true if submitted, 'remind' if reminded, false if closed otherwise.
+   */
+  async openSurvey(force = false, remindLaterCount = 0): Promise<boolean> {
+    // Prevent stacking multiple instances of the baseline survey dialog
+    const isOpen = this.dialog.openDialogs.some(
+      (d) => d.componentInstance instanceof BaselineSurveyComponent
+    );
+    if (isOpen) {
+      return false;
+    }
 
     const ref = this.dialog.open(BaselineSurveyComponent, {
       width: '720px',
-      disableClose: force,
+      maxWidth: '95vw',
+      disableClose: true,
       autoFocus: true,
-      data: { force }
+      data: { force, isMandatory: force, remindLaterCount }
     });
 
     const result = await firstValueFrom(ref.afterClosed());
-    if (result === true) localStorage.setItem(key, '1');
-    return result === true;
+    if (result === true) {
+      this.surveyService.setCompleted(true);
+      return true;
+    } else {
+      this.surveyService.setDismissed(true);
+      return false;
+    }
   }
 }

--- a/shiksha-website/shiksha-frontend/src/app/core/services/baseline-survey.service.ts
+++ b/shiksha-website/shiksha-frontend/src/app/core/services/baseline-survey.service.ts
@@ -57,7 +57,7 @@ export class BaselineSurveyService {
 
   checkCompleted(): Observable<{
     success: boolean;
-    data: { completed: boolean; remindLaterCount: number; isMandatory: boolean };
+    data: { completed: boolean; remindLaterCount: number; isMandatory: boolean; maxReminders: number };
   }> {
     const uid = this.getUserId();
     this.resetCacheIfNeeded(uid);
@@ -65,12 +65,12 @@ export class BaselineSurveyService {
     if (this.surveyCompleted === true) {
       return of({
         success: true,
-        data: { completed: true, remindLaterCount: 0, isMandatory: false },
+        data: { completed: true, remindLaterCount: 0, isMandatory: false, maxReminders: 0 },
       });
     }
 
     return this.http
-      .get<{ success: boolean; data: { completed: boolean; remindLaterCount: number; isMandatory: boolean } }>(
+      .get<{ success: boolean; data: { completed: boolean; remindLaterCount: number; isMandatory: boolean; maxReminders: number } }>(
         `${this.baseUrl}/check`
       )
       .pipe(
@@ -83,12 +83,13 @@ export class BaselineSurveyService {
               completed,
               remindLaterCount: res?.data?.remindLaterCount ?? 0,
               isMandatory: !!res?.data?.isMandatory,
+              maxReminders: res?.data?.maxReminders ?? 0,
             },
           };
         }),
         catchError(error => {
           console.error('Error checking survey status:', error);
-          return of({ success: false, data: { completed: false, remindLaterCount: 0, isMandatory: false } });
+          return of({ success: false, data: { completed: false, remindLaterCount: 0, isMandatory: false, maxReminders: 0 } });
         })
       );
   }

--- a/shiksha-website/shiksha-frontend/src/app/core/services/baseline-survey.service.ts
+++ b/shiksha-website/shiksha-frontend/src/app/core/services/baseline-survey.service.ts
@@ -9,8 +9,28 @@ export class BaselineSurveyService {
   private baseUrl = `${environment.apiUrl}/baseline-surveys`;
   private surveyCompleted: boolean | null = null;
   private cachedUserId: string | null = null;
+  private dismissedInSession = false;
 
   constructor(private http: HttpClient) {}
+
+  isDismissed(): boolean {
+    return this.dismissedInSession;
+  }
+
+  setDismissed(val: boolean): void {
+    this.dismissedInSession = val;
+  }
+
+  setCompleted(val: boolean): void {
+    this.surveyCompleted = val;
+  }
+
+  /** Call this on login to reset all session-level caches */
+  resetSession(): void {
+    this.dismissedInSession = false;
+    this.surveyCompleted = null;
+    this.cachedUserId = null;
+  }
 
   private getUserId(): string | null {
     try {
@@ -25,35 +45,50 @@ export class BaselineSurveyService {
     if (!userId) {
       this.cachedUserId = null;
       this.surveyCompleted = null;
+      this.dismissedInSession = false;
       return;
     }
-
     if (userId !== this.cachedUserId) {
       this.cachedUserId = userId;
       this.surveyCompleted = null;
+      this.dismissedInSession = false;
     }
   }
 
-  checkCompleted(): Observable<{ success: boolean; data: { completed: boolean } }> {
+  checkCompleted(): Observable<{
+    success: boolean;
+    data: { completed: boolean; remindLaterCount: number; isMandatory: boolean };
+  }> {
     const uid = this.getUserId();
-
     this.resetCacheIfNeeded(uid);
 
-    if (this.surveyCompleted !== null) {
-      return of({ success: true, data: { completed: this.surveyCompleted } });
+    if (this.surveyCompleted === true) {
+      return of({
+        success: true,
+        data: { completed: true, remindLaterCount: 0, isMandatory: false },
+      });
     }
 
     return this.http
-      .get<{ success: boolean; data: { completed: boolean } }>(`${this.baseUrl}/check`)
+      .get<{ success: boolean; data: { completed: boolean; remindLaterCount: number; isMandatory: boolean } }>(
+        `${this.baseUrl}/check`
+      )
       .pipe(
         map(res => {
           const completed = !!res?.data?.completed;
           this.surveyCompleted = completed;
-          return { success: !!res?.success, data: { completed } };
+          return {
+            success: !!res?.success,
+            data: {
+              completed,
+              remindLaterCount: res?.data?.remindLaterCount ?? 0,
+              isMandatory: !!res?.data?.isMandatory,
+            },
+          };
         }),
         catchError(error => {
           console.error('Error checking survey status:', error);
-          return of({ success: false, data: { completed: false } });
+          return of({ success: false, data: { completed: false, remindLaterCount: 0, isMandatory: false } });
         })
       );
   }
@@ -79,5 +114,19 @@ export class BaselineSurveyService {
         return of({ success: false, message: 'Failed to submit survey' });
       })
     );
+  }
+
+  remindLater(): Observable<{ success: boolean; data?: { remindLaterCount: number; isMandatory: boolean } }> {
+    return this.http
+      .patch<{ success: boolean; data: { remindLaterCount: number; isMandatory: boolean } }>(
+        `${this.baseUrl}/remind-later`,
+        {}
+      )
+      .pipe(
+        catchError(error => {
+          console.error('Error recording remind later:', error);
+          return of({ success: false });
+        })
+      );
   }
 }

--- a/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.html
+++ b/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.html
@@ -12,11 +12,12 @@
       <div class="intro-pills">
         <span class="pill pill-time">⏱ About 3 minutes</span>
         <span class="pill">9 quick questions</span>
-        <span class="pill pill-warn" *ngIf="isMandatory">Mandatory: you have reached the limit of reminders</span>
+        <span class="pill pill-warn" *ngIf="isMandatory">You have reached the maximum number of reminders. Please
+          complete the survey to continue.</span>
       </div>
 
       <h1>Baseline Survey</h1>
-      <p>Your feedback helps us make Shiksha Copilot more useful for teachers. This is not a test or evaluation please
+      <p>Your feedback helps us make Shiksha copilot more useful for teachers. This is not a test or evaluation, please
         answer based on your actual experience.</p>
 
       <div class="intro-actions">

--- a/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.html
+++ b/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.html
@@ -24,7 +24,7 @@
           (click)="onRemindLater()">
           <span *ngIf="!reminding">Remind me later</span>
           <mat-spinner *ngIf="reminding" diameter="18"></mat-spinner>
-          <span class="remind-count" *ngIf="remindLaterCount > 0">({{ 3 - remindLaterCount }} left)</span>
+          <span class="remind-count" *ngIf="remindLaterCount > 0">({{ MAX_REMINDERS - remindLaterCount }} left)</span>
         </button>
         <button type="button" class="btn btn-start" (click)="goNext()">Let's start →</button>
       </div>

--- a/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.html
+++ b/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.html
@@ -1,294 +1,266 @@
-<div class="survey-wrapper"><div class="survey-container">
-  <!-- HEADER -->
-  <div class="survey-hero">
-    <div class="survey-header">
-      <div class="survey-title-block">
-        <div class="survey-pill-row">
-          <span class="survey-pill primary">Please fill the Baseline Survey</span>
-          <span class="survey-pill">Takes ~ 1 minute</span>
-        </div>
+<div class="survey-wrapper">
+  <div class="wizard-card">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700&family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet">
+    <!-- INTRO SCREEN -->
+    <div class="intro-screen" *ngIf="currentStep === -1">
+      <div class="intro-badge">📝</div>
 
-        <div class="survey-info-banner">
-          <div class="info-icon">💡</div>
-          <div class="info-text">
-            <strong>Your responses will directly help us to improve the Shiksha copilot portal.</strong>
-          </div>
-        </div>
+      <div class="intro-pills">
+        <span class="pill pill-time">⏱ About 3 minutes</span>
+        <span class="pill">9 quick questions</span>
+        <span class="pill pill-warn" *ngIf="isMandatory">Mandatory: you have reached the limit of reminders</span>
       </div>
 
-      <!-- Right-side illustration -->
-      <div class="hero-illustration">
-        <div class="illustration-container">
-          <div class="teacher-avatar">
-            <div class="teacher-icon">👩‍🏫</div>
-          </div>
-          <div class="floating-elements">
-            <div class="floating-item item-1">📚</div>
-            <div class="floating-item item-2">✏️</div>
-            <div class="floating-item item-3">📝</div>
-          </div>
-        </div>
+      <h1>Baseline Survey</h1>
+      <p>Your feedback helps us make Shiksha Copilot more useful for teachers. This is not a test or evaluation please
+        answer based on your actual experience.</p>
+
+      <div class="intro-actions">
+        <button type="button" class="btn btn-remind" *ngIf="!isMandatory" [disabled]="reminding"
+          (click)="onRemindLater()">
+          <span *ngIf="!reminding">Remind me later</span>
+          <mat-spinner *ngIf="reminding" diameter="18"></mat-spinner>
+          <span class="remind-count" *ngIf="remindLaterCount > 0">({{ 3 - remindLaterCount }} left)</span>
+        </button>
+        <button type="button" class="btn btn-start" (click)="goNext()">Let's start →</button>
       </div>
     </div>
+
+    <!-- THANK YOU SCREEN -->
+    <div class="done-screen" *ngIf="submitted">
+      <div class="done-badge">✓</div>
+      <h1>Thank you!</h1>
+      <p>Your responses were submitted. They'll help make shiksha copilot more useful for teachers.</p>
+    </div>
+
+    <!-- QUESTION WIZARD -->
+    <form [formGroup]="surveyForm" *ngIf="currentStep > -1 && !submitted" class="wizard-form">
+
+      <div class="progress-block">
+        <div class="progress-top">
+          <span class="progress-label">Question {{ currentStep + 1 }} of {{ totalSteps }}</span>
+        </div>
+        <div class="tally-track">
+          <div class="tally" *ngFor="let s of stepProgressArray; let i = index" [class.done]="i < currentStep"
+            [class.current]="i === currentStep"></div>
+        </div>
+      </div>
+
+      <div class="stage">
+
+        <!-- Q1: plans -->
+        <ng-container *ngIf="currentStep === 0">
+          <h2 class="question">How do you currently prepare your lesson plans?</h2>
+          <p class="hint">Select all that apply</p>
+          <div class="options">
+            <div class="opt check" *ngFor="let o of planOptions" [class.selected]="isChecked('plans', o)"
+              (click)="toggleArray('plans', o)">
+              <span class="mark"></span><span>{{ o }}</span>
+            </div>
+          </div>
+          <div class="other-box" *ngIf="showPlansOther">
+            <input type="text" formControlName="plansOther" placeholder="Please specify" />
+            <div class="field-nudge"
+              *ngIf="surveyForm.get('plansOther')?.invalid && surveyForm.get('plansOther')?.touched">
+              Please specify.
+            </div>
+          </div>
+          <div class="field-nudge" *ngIf="surveyForm.get('plans')?.invalid && surveyForm.get('plans')?.touched">
+            Please select at least one option to continue.
+          </div>
+        </ng-container>
+
+        <!-- Q2: devices -->
+        <ng-container *ngIf="currentStep === 1">
+          <h2 class="question">Which of these do you use while preparing lesson plans?</h2>
+          <p class="hint">Select all that apply</p>
+          <div class="options">
+            <div class="opt check" *ngFor="let o of deviceOptions" [class.selected]="isChecked('devices', o)"
+              (click)="toggleArray('devices', o)">
+              <span class="mark"></span><span>{{ o }}</span>
+            </div>
+          </div>
+          <div class="other-box" *ngIf="showDevicesOther">
+            <input type="text" formControlName="devicesOther" placeholder="Please specify" />
+            <div class="field-nudge"
+              *ngIf="surveyForm.get('devicesOther')?.invalid && surveyForm.get('devicesOther')?.touched">
+              Please specify.
+            </div>
+          </div>
+          <div class="field-nudge" *ngIf="surveyForm.get('devices')?.invalid && surveyForm.get('devices')?.touched">
+            Please select at least one option to continue.
+          </div>
+        </ng-container>
+
+        <!-- Q3: weeklyLessonPlans -->
+        <ng-container *ngIf="currentStep === 2">
+          <h2 class="question">How many lesson plans do you create in a week?</h2>
+          <p class="hint">Pick one</p>
+          <div class="options grid2">
+            <div class="opt radio" *ngFor="let o of weeklyOptions"
+              [class.selected]="surveyForm.get('weeklyLessonPlans')?.value === o"
+              (click)="selectRadioValue('weeklyLessonPlans', o)">
+              <span class="mark"></span><span>{{ o }}</span>
+            </div>
+          </div>
+          <div class="field-nudge"
+            *ngIf="surveyForm.get('weeklyLessonPlans')?.invalid && surveyForm.get('weeklyLessonPlans')?.touched">
+            Please select how many lesson plans you create.
+          </div>
+        </ng-container>
+
+        <!-- Q4: lessonPlanComponents -->
+        <ng-container *ngIf="currentStep === 3">
+          <h2 class="question">Which components do you include in your lesson plans?</h2>
+          <p class="hint">Select all that apply</p>
+          <div class="exclusive-note" *ngIf="isExclusiveOptionActive('lessonPlanComponents')">
+            ℹ️ {{ exclusiveOptionMessage('lessonPlanComponents') }}
+          </div>
+          <div class="options">
+            <div class="opt check" *ngFor="let o of componentOptions"
+              [class.selected]="isChecked('lessonPlanComponents', o)"
+              [class.disabled]="isOptionDisabled('lessonPlanComponents', o)"
+              [title]="isOptionDisabled('lessonPlanComponents', o) ? exclusiveOptionMessage('lessonPlanComponents') : null"
+              (click)="!isOptionDisabled('lessonPlanComponents', o) && toggleArray('lessonPlanComponents', o)">
+              <span class="mark"></span><span>{{ o }}</span>
+            </div>
+          </div>
+          <div class="other-box" *ngIf="showLessonComponentsOther">
+            <input type="text" formControlName="lessonPlanComponentsOther"
+              placeholder="Please specify other components" />
+            <div class="field-nudge"
+              *ngIf="surveyForm.get('lessonPlanComponentsOther')?.invalid && surveyForm.get('lessonPlanComponentsOther')?.touched">
+              Please specify.
+            </div>
+          </div>
+          <div class="field-nudge"
+            *ngIf="surveyForm.get('lessonPlanComponents')?.invalid && surveyForm.get('lessonPlanComponents')?.touched">
+            Please select at least one component.
+          </div>
+        </ng-container>
+
+        <!-- Q5: timePerLessonPlan -->
+        <ng-container *ngIf="currentStep === 4">
+          <h2 class="question">On average, how much time do you spend preparing one lesson plan?</h2>
+          <p class="hint">Pick one</p>
+          <div class="options">
+            <div class="opt radio" *ngFor="let o of timePerLessonOptions"
+              [class.selected]="surveyForm.get('timePerLessonPlan')?.value === o"
+              (click)="selectRadioValue('timePerLessonPlan', o)">
+              <span class="mark"></span><span>{{ o }}</span>
+            </div>
+          </div>
+          <div class="other-box" *ngIf="showTimePerLessonOther">
+            <input type="text" formControlName="timePerLessonPlanOther" placeholder="Please specify" />
+            <div class="field-nudge"
+              *ngIf="surveyForm.get('timePerLessonPlanOther')?.invalid && surveyForm.get('timePerLessonPlanOther')?.touched">
+              Please specify.
+            </div>
+          </div>
+          <div class="field-nudge"
+            *ngIf="surveyForm.get('timePerLessonPlan')?.invalid && surveyForm.get('timePerLessonPlan')?.touched">
+            Please select an approximate time.
+          </div>
+        </ng-container>
+
+        <!-- Q6: resourcesUsed -->
+        <ng-container *ngIf="currentStep === 5">
+          <h2 class="question">Which resources do you use while preparing lesson plans?</h2>
+          <p class="hint">Select all that apply</p>
+          <div class="options">
+            <div class="opt check" *ngFor="let o of resourceOptions" [class.selected]="isChecked('resourcesUsed', o)"
+              (click)="toggleArray('resourcesUsed', o)">
+              <span class="mark"></span><span>{{ o }}</span>
+            </div>
+          </div>
+          <div class="other-box" *ngIf="showResourcesOther">
+            <input type="text" formControlName="resourcesUsedOther" placeholder="Please specify other resources" />
+            <div class="field-nudge"
+              *ngIf="surveyForm.get('resourcesUsedOther')?.invalid && surveyForm.get('resourcesUsedOther')?.touched">
+              Please specify.
+            </div>
+          </div>
+          <div class="field-nudge"
+            *ngIf="surveyForm.get('resourcesUsed')?.invalid && surveyForm.get('resourcesUsed')?.touched">
+            Please select at least one resource.
+          </div>
+        </ng-container>
+
+        <!-- Q7: timeForAssessments -->
+        <ng-container *ngIf="currentStep === 6">
+          <h2 class="question">On average, how much time do you spend creating questions for one Formative Assessment?
+          </h2>
+          <p class="hint">Pick one</p>
+          <div class="options">
+            <div class="opt radio" *ngFor="let o of timeAssessmentOptions"
+              [class.selected]="surveyForm.get('timeForAssessments')?.value === o"
+              (click)="selectRadioValue('timeForAssessments', o)">
+              <span class="mark"></span><span>{{ o }}</span>
+            </div>
+          </div>
+          <div class="other-box" *ngIf="showTimeAssessmentsOther">
+            <input type="text" formControlName="timeForAssessmentsOther" placeholder="Please specify" />
+            <div class="field-nudge"
+              *ngIf="surveyForm.get('timeForAssessmentsOther')?.invalid && surveyForm.get('timeForAssessmentsOther')?.touched">
+              Please specify.
+            </div>
+          </div>
+          <div class="field-nudge"
+            *ngIf="surveyForm.get('timeForAssessments')?.invalid && surveyForm.get('timeForAssessments')?.touched">
+            Please select how much time you spend on assessments.
+          </div>
+        </ng-container>
+
+        <!-- Q8: questionBalance -->
+        <ng-container *ngIf="currentStep === 7">
+          <h2 class="question">How do you ensure your question paper has a good balance of easy, medium and difficult
+            questions?</h2>
+          <p class="hint">Select all that apply</p>
+          <div class="options">
+            <div class="opt check" *ngFor="let o of questionBalanceOptions"
+              [class.selected]="isChecked('questionBalance', o)" (click)="toggleArray('questionBalance', o)">
+              <span class="mark"></span><span>{{ o }}</span>
+            </div>
+          </div>
+          <div class="other-box" *ngIf="showQuestionBalanceOther">
+            <input type="text" formControlName="questionBalanceOther" placeholder="Please specify" />
+            <div class="field-nudge"
+              *ngIf="surveyForm.get('questionBalanceOther')?.invalid && surveyForm.get('questionBalanceOther')?.touched">
+              Please specify.
+            </div>
+          </div>
+          <div class="field-nudge"
+            *ngIf="surveyForm.get('questionBalance')?.invalid && surveyForm.get('questionBalance')?.touched">
+            Please select at least one option.
+          </div>
+        </ng-container>
+
+        <!-- Q9: otherNotes (optional, final step) -->
+        <ng-container *ngIf="currentStep === 8">
+          <h2 class="question">Anything else you'd like us to know?</h2>
+          <p class="hint">Optional</p>
+          <textarea formControlName="otherNotes" rows="4" placeholder="Share any thoughts..."></textarea>
+        </ng-container>
+
+      </div>
+
+      <div class="nav">
+        <button type="button" class="btn btn-back" [disabled]="currentStep === 0" (click)="goBack()">← Back</button>
+        <button type="button" class="btn btn-next" [disabled]="submitting" (click)="goNext()">
+          <span *ngIf="!submitting">{{ nextButtonLabel }}</span>
+          <mat-spinner *ngIf="submitting" diameter="20"></mat-spinner>
+        </button>
+      </div>
+
+      <div *ngIf="error" class="error-message">
+        <mat-icon>error_outline</mat-icon>
+        <span>{{ error }}</span>
+      </div>
+    </form>
+
   </div>
-
-  <!-- FORM -->
-  <form [formGroup]="surveyForm" (ngSubmit)="onSubmit()" class="survey-form">
-    <!-- Q1 -->
-    <div class="form-group"
-         [class.has-error]="surveyForm.get('plans')?.invalid && surveyForm.get('plans')?.touched">
-      <div class="question-header">
-        <div class="question-number">1</div>
-        <label>
-          How do you currently plan your lessons?
-          <span class="label-pill">Select all that apply</span>
-        </label>
-      </div>
-      <div class="checkbox-group">
-        <label *ngFor="let o of planOptions" class="checkbox-card">
-          <input
-            type="checkbox"
-            (change)="toggleArray('plans', o)"
-            [checked]="isChecked('plans', o)"
-          />
-          <span class="checkmark"></span>
-          <span class="checkbox-text">{{ o }}</span>
-        </label>
-      </div>
-      <div class="field-error" *ngIf="surveyForm.get('plans')?.invalid && surveyForm.get('plans')?.touched">
-        Please select at least one option.
-      </div>
-    </div>
-
-    <!-- Q2 -->
-    <div class="form-group"
-         [class.has-error]="surveyForm.get('devices')?.invalid && surveyForm.get('devices')?.touched">
-      <div class="question-header">
-        <div class="question-number">2</div>
-        <label>
-          Which device do you use while creating lesson plans?
-          <span class="label-pill">Select all that apply</span>
-        </label>
-      </div>
-      <div class="checkbox-group">
-        <label *ngFor="let o of deviceOptions" class="checkbox-card">
-          <input
-            type="checkbox"
-            (change)="toggleArray('devices', o)"
-            [checked]="isChecked('devices', o)"
-          />
-          <span class="checkmark"></span>
-          <span class="checkbox-text">{{ o }}</span>
-        </label>
-      </div>
-      <div class="field-error" *ngIf="surveyForm.get('devices')?.invalid && surveyForm.get('devices')?.touched">
-        Please select at least one option.
-      </div>
-    </div>
-
-    <!-- Q3 -->
-    <div class="form-group"
-         [class.has-error]="surveyForm.get('weeklyLessonPlans')?.invalid && surveyForm.get('weeklyLessonPlans')?.touched">
-      <div class="question-header">
-        <div class="question-number">3</div>
-        <label>
-          How many lesson plans do you create in a week?
-          <span class="required-star">*</span>
-        </label>
-      </div>
-      <div class="select-wrapper">
-        <select formControlName="weeklyLessonPlans" class="form-control">
-          <option value="">Select</option>
-          <option *ngFor="let o of weeklyOptions" [value]="o">{{ o }}</option>
-        </select>
-        <div class="select-arrow">▼</div>
-      </div>
-      <div class="field-error" *ngIf="surveyForm.get('weeklyLessonPlans')?.invalid && surveyForm.get('weeklyLessonPlans')?.touched">
-        Please select how many lesson plans you create.
-      </div>
-    </div>
-
-    <!-- Q4 -->
-    <div class="form-group"
-         [class.has-error]="surveyForm.get('lessonPlanComponents')?.invalid && surveyForm.get('lessonPlanComponents')?.touched">
-      <div class="question-header">
-        <div class="question-number">4</div>
-        <label>
-          Which components do you include in your lesson plans?
-          <span class="label-pill">Select all that apply</span>
-        </label>
-      </div>
-      <div class="checkbox-group">
-        <label *ngFor="let o of componentOptions" class="checkbox-card">
-          <input
-            type="checkbox"
-            (change)="toggleArray('lessonPlanComponents', o)"
-            [checked]="isChecked('lessonPlanComponents', o)"
-          />
-          <span class="checkmark"></span>
-          <span class="checkbox-text">{{ o }}</span>
-        </label>
-      </div>
-      <div class="field-error" *ngIf="surveyForm.get('lessonPlanComponents')?.invalid && surveyForm.get('lessonPlanComponents')?.touched">
-        Please select at least one component.
-      </div>
-
-      <!-- Others input -->
-      <div class="other-input" *ngIf="showOtherLessonComponent">
-        <input
-          type="text"
-          class="form-control"
-          formControlName="otherLessonPlanComponent"
-          placeholder="Please specify other components"
-        />
-      </div>
-    </div>
-
-    <!-- Q5 -->
-    <div class="form-group"
-         [class.has-error]="surveyForm.get('timePerLessonPlan')?.invalid && surveyForm.get('timePerLessonPlan')?.touched">
-      <div class="question-header">
-        <div class="question-number">5</div>
-        <label>
-         On average, how much time do you spend creating a single lesson plan (including activities such as hands-on tasks, real-world examples, stories, and videos)?
-          <span class="required-star">*</span>
-        </label>
-      </div>
-      <div class="select-wrapper">
-        <select formControlName="timePerLessonPlan" class="form-control">
-          <option value="">Select</option>
-          <option *ngFor="let o of timeOptions" [value]="o">{{ o }}</option>
-        </select>
-        <div class="select-arrow">▼</div>
-      </div>
-      <div class="field-error" *ngIf="surveyForm.get('timePerLessonPlan')?.invalid && surveyForm.get('timePerLessonPlan')?.touched">
-        Please select an approximate time.
-      </div>
-
-      <!-- Others input -->
-      <div class="other-input" *ngIf="showOtherTimePerLessonPlan">
-        <input
-          type="text"
-          class="form-control"
-          formControlName="otherTimePerLessonPlan"
-          placeholder="Please specify the time taken"
-        />
-      </div>
-    </div>
-
-    <!-- Q6 -->
-    <div class="form-group"
-         [class.has-error]="surveyForm.get('resourcesUsed')?.invalid && surveyForm.get('resourcesUsed')?.touched">
-      <div class="question-header">
-        <div class="question-number">6</div>
-        <label>
-          Which resources do you use while planning?
-          <span class="label-pill">Select all that apply</span>
-        </label>
-      </div>
-      <div class="checkbox-group">
-        <label *ngFor="let o of resourceOptions" class="checkbox-card">
-          <input
-            type="checkbox"
-            (change)="toggleArray('resourcesUsed', o)"
-            [checked]="isChecked('resourcesUsed', o)"
-          />
-          <span class="checkmark"></span>
-          <span class="checkbox-text">{{ o }}</span>
-        </label>
-      </div>
-      <div class="field-error" *ngIf="surveyForm.get('resourcesUsed')?.invalid && surveyForm.get('resourcesUsed')?.touched">
-        Please select at least one resource.
-      </div>
-
-      <!-- Others input -->
-      <div class="other-input" *ngIf="showOtherResourceUsed">
-        <input
-          type="text"
-          class="form-control"
-          formControlName="otherResourceUsed"
-          placeholder="Please specify other resources"
-        />
-      </div>
-    </div>
-
-    <!-- Q7 -->
-    <div class="form-group"
-         [class.has-error]="surveyForm.get('timeForAssessments')?.invalid && surveyForm.get('timeForAssessments')?.touched">
-      <div class="question-header">
-        <div class="question-number">7</div>
-        <label>
-           On average, how much time do you spend creating assessments for each subject (Unit level, Formative Assessment, Summative Assessment)?
-          <span class="required-star">*</span>
-        </label>
-      </div>
-      <div class="select-wrapper">
-        <select formControlName="timeForAssessments" class="form-control">
-          <option value="">Select</option>
-          <option *ngFor="let o of assessOptions" [value]="o">{{ o }}</option>
-        </select>
-        <div class="select-arrow">▼</div>
-      </div>
-      <div class="field-error" *ngIf="surveyForm.get('timeForAssessments')?.invalid && surveyForm.get('timeForAssessments')?.touched">
-        Please select how much time you spend on assessments.
-      </div>
-
-      <!-- Others input -->
-      <div class="other-input" *ngIf="showOtherTimeForAssessments">
-        <input
-          type="text"
-          class="form-control"
-          formControlName="otherTimeForAssessments"
-          placeholder="Please specify the time spent on assessments"
-        />
-      </div>
-    </div>
-
-    <!-- NOTES -->
-    <div class="form-group">
-      <div class="question-header">
-        <div class="question-number">8</div>
-        <label>Other notes or comments (optional)</label>
-      </div>
-      <div class="textarea-wrapper">
-        <textarea
-          formControlName="otherNotes"
-          rows="3"
-          class="form-control"
-          placeholder="Anything else about your lesson planning process that you would like us to know?"
-        ></textarea>
-      </div>
-    </div>
-
-    <!-- ACTIONS -->
-    <div class="form-actions">
-      <button
-        mat-button
-        type="button"
-        (click)="onClose()"
-        [disabled]="submitting"
-        *ngIf="!data?.force"
-        class="btn-cancel"
-      >
-        Cancel
-      </button>
-      <button
-        mat-raised-button
-        color="primary"
-        type="submit"
-        [disabled]="surveyForm.invalid || submitting"
-        class="btn-submit"
-      >
-        <span *ngIf="!submitting">Submit Survey</span>
-        <mat-spinner *ngIf="submitting" diameter="20"></mat-spinner>
-      </button>
-    </div>
-
-    <!-- ERROR -->
-    <div *ngIf="error" class="error-message">
-      <mat-icon>error_outline</mat-icon>
-      <span>{{ error }}</span>
-    </div>
-  </form>
-</div>
 </div>

--- a/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.html
+++ b/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.html
@@ -24,7 +24,7 @@
           (click)="onRemindLater()">
           <span *ngIf="!reminding">Remind me later</span>
           <mat-spinner *ngIf="reminding" diameter="18"></mat-spinner>
-          <span class="remind-count" *ngIf="remindLaterCount > 0">({{ MAX_REMINDERS - remindLaterCount }} left)</span>
+          <span class="remind-count" *ngIf="remindLaterCount > 0">({{ maxReminders - remindLaterCount }} left)</span>
         </button>
         <button type="button" class="btn btn-start" (click)="goNext()">Let's start →</button>
       </div>

--- a/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.scss
+++ b/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.scss
@@ -1,618 +1,569 @@
-// new
-/* Make the Angular Material dialog hug the survey nicely */
+// @import url('https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700&family=Inter:wght@400;500;600;700&display=swap');
 
-.survey-wrapper{
-:host ::ng-deep .mat-dialog-container {
-  padding: 0;
-  max-width: 100vw;
-  overflow: hidden;
-  box-shadow: 0 25px 50px -12px rgba(75, 75, 75, 0.25);
-  box-shadow: 0 25px 50px -12px color-mix(in srgb, var(--content-DEFAULT) 25%, transparent);
-}
+/* Make the Angular Material dialog hug the wizard card */
+.survey-wrapper {
+  :host ::ng-deep .mat-dialog-container {
+    padding: 0;
+    max-width: 100vw;
+    overflow: hidden;
+    box-shadow: 0 25px 50px -12px rgba(30, 41, 59, 0.25);
+  }
 
-/* MAIN CONTAINER */
-.survey-container {
-  width: 100%;
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 0;
-  background: linear-gradient(135deg, var(--surface-muted) 0%, var(--shade-80) 100%);
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  max-height: 85vh;
-  overflow-y: auto;
-  overflow-x: hidden;
-  box-sizing: border-box;
-  position: relative;
-}
+  --blue: #3F91DA;
+  --blue-deep: #2C74B5;
+  --blue-pale: #EAF3FB;
+  --ink: #1E293B;
+  --ink-soft: #64748B;
+  --line: #E2E8F0;
+  --panel: #F8FAFC;
+  --success: #2E9E6F;
+  --danger: #DC2626;
+  --warn-bg: #FFF3E0;
+  --warn-border: #FFE0B2;
+  --warn-text: #92601A;
+  --disabled-bg: #F1F5F9;
+  --disabled-border: #E2E8F0;
+  --disabled-text: #94A3B8;
 
-/* HEADER SECTION */
-.survey-hero {
-  background: linear-gradient(135deg, var(--primary-DEFAULT) 0%, var(--primary-DEFAULT) 100%);
-  padding: 32px 40px 24px;
-  color: var(--surface-DEFAULT);
-  position: relative;
-  overflow: hidden;
-}
-
-.survey-hero::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.05'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
-}
-
-.survey-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  position: relative;
-  z-index: 1;
-}
-
-.survey-title-block {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  flex: 1;
-}
-
-.survey-pill-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.survey-pill {
-  font-size: 0.75rem;
-  font-weight: 600;
-  padding: 6px 12px;
-  border-radius: 20px;
-  background: rgba(255, 255, 255, 0.2);
-  background: color-mix(in srgb, var(--surface-DEFAULT) 20%, transparent);
-  color: rgba(255, 255, 255, 0.9);
-  color: color-mix(in srgb, var(--surface-DEFAULT) 90%, transparent);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  backdrop-filter: blur(10px);
-}
-
-.survey-pill.primary {
-  background: rgba(255, 255, 255, 0.3);
-  background: color-mix(in srgb, var(--surface-DEFAULT) 30%, transparent);
-  color: var(--surface-DEFAULT);
-}
-
-.survey-info-banner {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-  background: rgba(255, 255, 255, 0.15);
-  background: color-mix(in srgb, var(--surface-DEFAULT) 15%, transparent);
-  border-radius: 12px;
-  padding: 14px 16px;
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border: 1px solid color-mix(in srgb, var(--surface-DEFAULT) 20%, transparent);
-  max-width: 500px;
-  margin-top: 8px;
-}
-
-.survey-info-banner .info-icon {
-  width: 28px;
-  height: 28px;
-  border-radius: 999px;
-  background: var(--surface-DEFAULT);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  color: var(--tertiary-DEFAULT);
-  font-size: 14px;
-}
-
-.survey-info-banner .info-text {
-  color: var(--surface-DEFAULT);
-  font-size: 0.9rem;
-}
-
-/* HERO ILLUSTRATION */
-.hero-illustration {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-left: 20px;
-}
-
-.illustration-container {
-  position: relative;
-  width: 140px;
-  height: 140px;
-}
-
-.teacher-avatar {
-  width: 100px;
-  height: 100px;
-  border-radius: 50%;
-  background: var(--surface-DEFAULT);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: absolute;
-  top: 20px;
-  left: 20px;
-  box-shadow: 0 10px 25px rgba(75, 75, 75, 0.15);
-  box-shadow: 0 10px 25px color-mix(in srgb, var(--content-DEFAULT) 15%, transparent);
-  z-index: 2;
-}
-
-.teacher-icon {
-  font-size: 40px;
-}
-
-.floating-elements {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-}
-
-.floating-item {
-  position: absolute;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  background: var(--surface-DEFAULT);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 5px 15px rgba(75, 75, 75, 0.1);
-  box-shadow: 0 5px 15px color-mix(in srgb, var(--content-DEFAULT) 10%, transparent);
-  animation: float 6s ease-in-out infinite;
-}
-
-.item-1 {
-  top: 0;
-  left: 0;
-  animation-delay: 0s;
-}
-
-.item-2 {
-  top: 10px;
-  right: 0;
-  animation-delay: 2s;
-}
-
-.item-3 {
-  bottom: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  animation-delay: 4s;
-}
-
-@keyframes float {
-  0% { transform: translateY(0px); }
-  50% { transform: translateY(-10px); }
-  100% { transform: translateY(0px); }
-}
-
-/* FORM LAYOUT */
-.survey-form {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-  padding: 32px 40px;
+  font-family: 'Inter',
+  -apple-system,
+  BlinkMacSystemFont,
+  'Segoe UI',
+  Roboto,
+  sans-serif;
   width: 100%;
   box-sizing: border-box;
-}
 
-/* QUESTION STYLING */
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  background: var(--surface-DEFAULT);
-  padding: 24px;
-  border-radius: 16px;
-  box-shadow: 0 4px 12px rgba(75, 75, 75, 0.05);
-  box-shadow: 0 4px 12px color-mix(in srgb, var(--content-DEFAULT) 5%, transparent);
-  border: 1px solid rgba(75, 75, 75, 0.04);
-  border: 1px solid color-mix(in srgb, var(--content-DEFAULT) 4%, transparent);
-  transition: all 0.3s ease;
-  position: relative;
-  overflow: hidden;
-  width: 100%;
-  box-sizing: border-box;
-}
-
-.form-group:hover {
-  box-shadow: 0 8px 25px rgba(75, 75, 75, 0.08);
-  box-shadow: 0 8px 25px color-mix(in srgb, var(--content-DEFAULT) 8%, transparent);
-  transform: translateY(-2px);
-}
-
-.question-header {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-}
-
-.question-number {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, var(--primary-DEFAULT) 0%, var(--primary-DEFAULT) 100%);
-  color: var(--surface-DEFAULT);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 600;
-  font-size: 0.9rem;
-  flex-shrink: 0;
-}
-
-.form-group label {
-  font-weight: 600;
-  color: var(--content-DEFAULT);
-  font-size: 1rem;
-  line-height: 1.5;
-  margin: 0;
-  flex: 1;
-}
-
-.label-pill {
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--primary-DEFAULT);
-  background: var(--primary-50);
-  padding: 4px 10px;
-  border-radius: 20px;
-  margin-left: 8px;
-}
-
-.required-star {
-  color: var(--error-DEFAULT);
-  font-size: 0.9rem;
-  font-weight: 600;
-  margin-left: 4px;
-}
-
-/* CHECKBOX GROUP */
-.checkbox-group {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 12px;
-  margin-top: 8px;
-  width: 100%;
-  box-sizing: border-box;
-}
-
-.checkbox-card {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  padding: 14px 16px;
-  margin: 0;
-  font-size: 0.95rem;
-  border-radius: 12px;
-  transition: all 0.2s ease;
-  position: relative;
-  background: var(--surface-muted);
-  border: 1.5px solid transparent;
-  width: 100%;
-  box-sizing: border-box;
-}
-
-.checkbox-card:hover {
-  background: var(--shade-80);
-  border-color: var(--content-30);
-}
-
-.checkbox-card input[type='checkbox'] {
-  position: absolute;
-  opacity: 0;
-  cursor: pointer;
-  height: 0;
-  width: 0;
-}
-
-.checkmark {
-  height: 20px;
-  width: 20px;
-  background-color: var(--shade-80);
-  border-radius: 6px;
-  border: 2px solid var(--content-30);
-  position: relative;
-  transition: all 0.2s ease;
-  flex-shrink: 0;
-}
-
-.checkbox-card:hover .checkmark {
-  border-color: var(--content-50);
-}
-
-.checkbox-card input:checked ~ .checkmark {
-  background-color: var(--primary-DEFAULT);
-  border-color: var(--primary-DEFAULT);
-}
-
-.checkmark:after {
-  content: "";
-  position: absolute;
-  display: none;
-  left: 6px;
-  top: 2px;
-  width: 5px;
-  height: 10px;
-  border: solid var(--surface-DEFAULT);
-  border-width: 0 2px 2px 0;
-  transform: rotate(45deg);
-}
-
-.checkbox-card input:checked ~ .checkmark:after {
-  display: block;
-}
-
-.checkbox-card:has(input:checked) {
-  background: var(--primary-50);
-  border-color: var(--primary-DEFAULT);
-  color: var(--primary-DEFAULT);
-  font-weight: 600;
-}
-
-.checkbox-text {
-  flex: 1;
-}
-
-/* SELECT STYLING */
-.select-wrapper {
-  position: relative;
-  width: 100%;
-}
-
-.form-control {
-  width: 100%;
-  padding: 5px 16px;
-  border: 1.5px solid var(--content-30);
-  border-radius: 12px;
-  font-size: 15px;
-  font-family: inherit;
-  background: var(--surface-muted);
-  transition: all 0.3s ease;
-  box-sizing: border-box;
-  appearance: none;
-}
-
-.form-control:focus {
-  outline: none;
-  border-color: var(--primary-DEFAULT);
-  background: var(--surface-DEFAULT);
-  box-shadow: 0 0 0 3px rgba(70, 160, 241, 0.1);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary-DEFAULT) 10%, transparent);
-}
-
-.select-arrow {
-  position: absolute;
-  right: 16px;
-  top: 50%;
-  transform: translateY(-50%);
-  pointer-events: none;
-  color: var(--content-60);
-  font-size: 12px;
-}
-
-/* TEXTAREA STYLING */
-.textarea-wrapper {
-  width: 100%;
-}
-
-textarea.form-control {
-  min-height: 100px;
-  resize: vertical;
-  line-height: 1.6;
-}
-
-/* ACTIONS */
-.form-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 16px;
-  margin-top: 24px;
-  padding-top: 20px;
-  border-top: 1px solid rgba(75, 75, 75, 0.08);
-  border-top: 1px solid color-mix(in srgb, var(--content-DEFAULT) 8%, transparent);
-  width: 100%;
-  box-sizing: border-box;
-}
-
-.btn-cancel, .btn-submit {
-  padding: 14px 28px;
-  border-radius: 12px;
-  font-weight: 600;
-  font-size: 15px;
-  border: none;
-  cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  min-width: 140px;
-  position: relative;
-  overflow: hidden;
-  box-sizing: border-box;
-}
-
-.btn-cancel {
-  background: var(--surface-muted);
-  color: var(--content-60);
-  border: 1.5px solid var(--content-30);
-}
-
-.btn-cancel:hover:not(:disabled) {
-  background: var(--shade-80);
-  color: var(--content-100);
-  border-color: var(--content-50);
-  transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(110, 119, 135, 0.15);
-  box-shadow: 0 8px 20px color-mix(in srgb, var(--content-60) 15%, transparent);
-}
-
-.btn-submit {
-  background: linear-gradient(135deg, var(--primary-DEFAULT) 0%, var(--tertiary-DEFAULT) 100%);
-  color: var(--surface-DEFAULT);
-  box-shadow: 0 4px 12px rgba(131, 83, 226, 0.3);
-  box-shadow: 0 4px 12px color-mix(in srgb, var(--tertiary-DEFAULT) 30%, transparent);
-}
-
-.btn-submit:hover:not(:disabled) {
-  background: linear-gradient(135deg, var(--primary-DEFAULT) 0%, var(--tertiary-100) 100%);
-  transform: translateY(-2px);
-  box-shadow: 0 8px 24px rgba(131, 83, 226, 0.4);
-  box-shadow: 0 8px 24px color-mix(in srgb, var(--tertiary-DEFAULT) 40%, transparent);
-}
-
-.btn-cancel:active:not(:disabled), .btn-submit:active:not(:disabled) {
-  transform: translateY(0);
-}
-
-.btn-cancel:disabled, .btn-submit:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-  transform: none !important;
-}
-
-/* ERROR MESSAGE */
-.error-message {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  color: var(--error-DEFAULT);
-  background: var(--error-50);
-  padding: 16px 20px;
-  border-radius: 12px;
-  margin-top: 20px;
-  font-size: 14px;
-  font-weight: 500;
-  border: 1px solid var(--error-100);
-  width: 100%;
-  box-sizing: border-box;
-}
-
-.error-message mat-icon {
-  font-size: 20px;
-  width: 20px;
-  height: 20px;
-  flex-shrink: 0;
-}
-
-/* CUSTOM SCROLLBAR */
-.survey-container::-webkit-scrollbar {
-  width: 8px;
-}
-
-.survey-container::-webkit-scrollbar-track {
-  background: var(--shade-80);
-  border-radius: 4px;
-}
-
-.survey-container::-webkit-scrollbar-thumb {
-  background: linear-gradient(135deg, var(--content-30) 0%, var(--content-50) 100%);
-  border-radius: 4px;
-}
-
-.survey-container::-webkit-scrollbar-thumb:hover {
-  background: linear-gradient(135deg, var(--content-50) 0%, var(--content-60) 100%);
-}
-
-/* RESPONSIVE BREAKPOINTS */
-@media (max-width: 768px) {
-  .survey-container {
-    max-height: 90vh;
-    border-radius: 12px;
+  * {
+    box-sizing: border-box;
   }
-  
-  .survey-hero {
-    padding: 24px 20px 20px;
-  }
-  
-  .survey-header {
-    flex-direction: column;
-    gap: 16px;
-  }
-  
-  .hero-illustration {
-    margin-left: 0;
-    align-self: center;
-  }
-  
-  .illustration-container {
-    width: 120px;
-    height: 120px;
-  }
-  
-  .teacher-avatar {
-    width: 80px;
-    height: 80px;
-  }
-  
-  .teacher-icon {
-    font-size: 32px;
-  }
-  
-  .floating-item {
-    width: 32px;
-    height: 32px;
-    font-size: 14px;
-  }
-  
-  .survey-form {
-    padding: 24px 20px;
-  }
-  
-  .form-group {
-    padding: 20px;
-  }
-  
-  .checkbox-group {
-    grid-template-columns: 1fr;
-  }
-  
-  .form-actions {
-    flex-direction: column;
-    gap: 12px;
-  }
-  
-  .btn-cancel, .btn-submit {
+
+  .wizard-card {
     width: 100%;
-    min-width: auto;
+    max-width: 640px;
+    margin: 0 auto;
+    background: #ffffff;
+    max-height: 85vh;
+    overflow-y: auto;
+    overflow-x: hidden;
+    position: relative;
   }
-}
 
-@media (max-width: 480px) {
-  .survey-container {
-    max-height: 95vh;
+  /* ---------- INTRO SCREEN ---------- */
+  .intro-screen {
+    padding: 44px 36px 40px;
+    text-align: center;
   }
-  
-  .survey-hero {
-    padding: 20px 16px 16px;
+
+  .intro-badge {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--blue), var(--blue-deep));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 28px;
+    margin: 0 auto 18px;
+    box-shadow: 0 10px 24px -8px rgba(63, 145, 218, 0.5);
   }
-  
-  .survey-form {
-    padding: 20px 16px;
-  }
-  
-  .form-group {
-    padding: 16px;
-  }
-  
-  .question-header {
-    flex-direction: column;
+
+  .intro-pills {
+    display: flex;
     gap: 8px;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-bottom: 20px;
   }
-  
-  .question-number {
-    align-self: flex-start;
-  }
-}
 
+  .pill {
+    font-size: 0.78rem;
+    font-weight: 600;
+    padding: 6px 14px;
+    border-radius: 20px;
+    background: var(--blue-pale);
+    color: var(--blue-deep);
+  }
+
+  .pill-time {
+    background: var(--blue-pale);
+    color: var(--blue-deep);
+  }
+
+  .pill-warn {
+    background: #FEF2F2;
+    color: var(--danger);
+  }
+
+  .intro-screen h1 {
+    font-family: 'Baloo 2', sans-serif;
+    font-size: 1.6rem;
+    font-weight: 600;
+    color: var(--ink);
+    margin: 0 0 10px;
+  }
+
+  .intro-screen p {
+    color: var(--ink-soft);
+    font-size: 0.95rem;
+    line-height: 1.6;
+    max-width: 440px;
+    margin: 0 auto 28px;
+  }
+
+  .intro-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    max-width: 340px;
+    margin: 0 auto;
+  }
+
+  /* ---------- DONE SCREEN ---------- */
+  .done-screen {
+    padding: 56px 36px;
+    text-align: center;
+  }
+
+  .done-badge {
+    width: 72px;
+    height: 72px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #3EBE8C, var(--success));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 32px;
+    color: white;
+    margin: 0 auto 20px;
+    box-shadow: 0 10px 24px -8px rgba(46, 158, 111, 0.45);
+  }
+
+  .done-screen h1 {
+    font-family: 'Baloo 2', sans-serif;
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--ink);
+    margin: 0 0 8px;
+  }
+
+  .done-screen p {
+    color: var(--ink-soft);
+    font-size: 0.93rem;
+    line-height: 1.6;
+  }
+
+  /* ---------- PROGRESS / TALLY TRACK ---------- */
+  .progress-block {
+    padding: 24px 32px 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .progress-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .progress-label {
+    font-size: 0.85rem;
+    color: var(--ink-soft);
+    font-weight: 500;
+  }
+
+  .tally-track {
+    display: flex;
+    gap: 5px;
+  }
+
+  .tally {
+    flex: 1;
+    height: 8px;
+    border-radius: 6px;
+    background: var(--line);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .tally::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, var(--blue), var(--blue-deep));
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0.4s cubic-bezier(.4, 0, .2, 1);
+    border-radius: 6px;
+  }
+
+  .tally.done::after {
+    transform: scaleX(1);
+  }
+
+  .tally.current::after {
+    transform: scaleX(1);
+    opacity: 0.55;
+  }
+
+  /* ---------- QUESTION STAGE ---------- */
+  .stage {
+    padding: 28px 32px 24px;
+    min-height: 320px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .question {
+    font-family: 'Baloo 2', sans-serif;
+    font-size: 1.25rem;
+    font-weight: 600;
+    line-height: 1.4;
+    color: var(--ink);
+    margin: 0 0 4px;
+  }
+
+  .hint {
+    font-size: 0.85rem;
+    color: var(--ink-soft);
+    margin: 0 0 20px;
+  }
+
+  /* Explanatory note shown when an exclusive option (e.g. "None of the above")
+     is selected and other options are locked */
+  .exclusive-note {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.82rem;
+    color: var(--warn-text);
+    background: var(--warn-bg);
+    border: 1px solid var(--warn-border);
+    border-radius: 10px;
+    padding: 10px 14px;
+    margin-bottom: 14px;
+  }
+
+  .options {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .options.grid2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+  }
+
+  .opt {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 16px;
+    border-radius: 14px;
+    border: 1.5px solid var(--line);
+    background: var(--panel);
+    cursor: pointer;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--ink);
+    transition: all 0.15s ease;
+    user-select: none;
+  }
+
+  .opt:hover {
+    border-color: #A9CBEA;
+    background: var(--blue-pale);
+  }
+
+  .opt .mark {
+    width: 22px;
+    height: 22px;
+    border-radius: 7px;
+    border: 2px solid #C9D6E4;
+    background: #fff;
+    flex-shrink: 0;
+    position: relative;
+    transition: all 0.15s ease;
+  }
+
+  .opt.radio .mark {
+    border-radius: 50%;
+  }
+
+  .opt.selected {
+    background: var(--blue-pale);
+    border-color: var(--blue);
+    color: var(--blue-deep);
+    font-weight: 600;
+  }
+
+  .opt.selected .mark {
+    background: var(--blue);
+    border-color: var(--blue);
+  }
+
+  .opt.selected.check .mark::after {
+    content: '✓';
+    position: absolute;
+    inset: 0;
+    color: white;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .opt.selected.radio .mark::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: white;
+    transform: translate(-50%, -50%);
+  }
+
+  /* Disabled option: clearly greyed out, not just slightly faded.
+     Used when an exclusive option like "None of the above" is selected. */
+  .opt.disabled {
+    background: var(--disabled-bg);
+    border-color: var(--disabled-border);
+    color: var(--disabled-text);
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  .opt.disabled:hover {
+    background: var(--disabled-bg);
+    border-color: var(--disabled-border);
+  }
+
+  .opt.disabled span {
+    color: var(--disabled-text);
+  }
+
+  .opt.disabled .mark {
+    background: var(--disabled-border);
+    border-color: #CBD5E1;
+  }
+
+  /* In case an option was checked before becoming disabled, keep it muted
+     rather than blue */
+  .opt.disabled.selected {
+    background: var(--disabled-bg);
+    border-color: var(--disabled-border);
+    color: var(--disabled-text);
+  }
+
+  .opt.disabled.selected .mark {
+    background: #CBD5E1;
+    border-color: #CBD5E1;
+  }
+
+  .other-box {
+    margin-top: 12px;
+  }
+
+  .other-box input {
+    width: 100%;
+    padding: 12px 14px;
+    border-radius: 12px;
+    border: 1.5px solid var(--line);
+    font-family: 'Inter', sans-serif;
+    font-size: 0.92rem;
+    background: var(--panel);
+  }
+
+  .other-box input:focus {
+    outline: none;
+    border-color: var(--blue);
+    background: white;
+    box-shadow: 0 0 0 3px rgba(63, 145, 218, 0.12);
+  }
+
+  textarea {
+    width: 100%;
+    min-height: 120px;
+    border-radius: 14px;
+    border: 1.5px solid var(--line);
+    padding: 14px 16px;
+    font-family: 'Inter', sans-serif;
+    font-size: 0.95rem;
+    resize: vertical;
+    background: var(--panel);
+  }
+
+  textarea:focus {
+    outline: none;
+    border-color: var(--blue);
+    background: white;
+    box-shadow: 0 0 0 3px rgba(63, 145, 218, 0.12);
+  }
+
+  .field-nudge {
+    font-size: 0.8rem;
+    color: var(--danger);
+    margin-top: 10px;
+  }
+
+  /* ---------- NAV ---------- */
+  .nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    padding: 18px 32px 28px;
+    border-top: 1px solid var(--line);
+  }
+
+  .btn {
+    font-family: 'Inter', sans-serif;
+    font-weight: 600;
+    font-size: 0.92rem;
+    border: none;
+    border-radius: 12px;
+    padding: 12px 22px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+  }
+
+  .btn-back {
+    background: transparent;
+    color: var(--ink-soft);
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+
+  .btn-back:hover:not(:disabled) {
+    color: var(--ink);
+  }
+
+  .btn-back:disabled {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .btn-next,
+  .btn-start {
+    background: linear-gradient(135deg, var(--blue), var(--blue-deep));
+    color: white;
+    box-shadow: 0 8px 20px -6px rgba(44, 116, 181, 0.45);
+    min-width: 130px;
+  }
+
+  .btn-next:hover:not(:disabled),
+  .btn-start:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 24px -6px rgba(44, 116, 181, 0.55);
+  }
+
+  .btn-next:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+    transform: none;
+  }
+
+  .btn-remind {
+    background: #F8FAFC;
+    color: var(--ink-soft);
+    border: 1.5px solid var(--line);
+  }
+
+  .btn-remind:hover:not(:disabled) {
+    background: #F1F5F9;
+    border-color: #CBD5E1;
+  }
+
+  .remind-count {
+    font-size: 0.8em;
+    opacity: 0.75;
+  }
+
+  /* ---------- ERROR MESSAGE ---------- */
+  .error-message {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    color: var(--danger);
+    background: #FEF2F2;
+    padding: 14px 20px 18px;
+    margin: 0 32px 20px;
+    border-radius: 12px;
+    font-size: 14px;
+    font-weight: 500;
+    border: 1px solid #FECACA;
+  }
+
+  .error-message mat-icon {
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+  }
+
+  /* ---------- SCROLLBAR ---------- */
+  .wizard-card::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  .wizard-card::-webkit-scrollbar-track {
+    background: var(--panel);
+    border-radius: 4px;
+  }
+
+  .wizard-card::-webkit-scrollbar-thumb {
+    background: #CBD5E1;
+    border-radius: 4px;
+  }
+
+  .wizard-card::-webkit-scrollbar-thumb:hover {
+    background: #94A3B8;
+  }
+
+  /* ---------- RESPONSIVE ---------- */
+  @media (max-width: 768px) {
+    .wizard-card {
+      max-height: 90vh;
+    }
+
+    .intro-screen {
+      padding: 32px 24px 28px;
+    }
+
+    .progress-block {
+      padding: 20px 20px 0;
+    }
+
+    .stage {
+      padding: 22px 20px 18px;
+      min-height: 260px;
+    }
+
+    .nav {
+      padding: 16px 20px 22px;
+    }
+
+    .options.grid2 {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .options.grid2 {
+      grid-template-columns: 1fr;
+    }
+
+    .intro-actions {
+      max-width: 100%;
+    }
+  }
 }

--- a/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.spec.ts
+++ b/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.spec.ts
@@ -1,14 +1,3 @@
-import { MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { MatDialogRef } from '@angular/material/dialog';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { NgIdleModule } from '@ng-idle/core';
-import { DatePipe } from '@angular/common';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { TranslateModule } from '@ngx-translate/core';
-import { RouterTestingModule } from '@angular/router/testing';
-import { ToastrModule } from 'ngx-toastr';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BaselineSurveyComponent } from './baseline-survey.component';
@@ -19,10 +8,8 @@ describe('BaselineSurveyComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [{ provide: MAT_DIALOG_DATA, useValue: {} }, { provide: MatDialogRef, useValue: {} }, DatePipe],
-      imports: [MatSnackBarModule, NgIdleModule.forRoot(), TranslateModule.forRoot(), RouterTestingModule, ToastrModule.forRoot(), HttpClientTestingModule],
-      declarations: [BaselineSurveyComponent],
-      schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA]});
+      declarations: [BaselineSurveyComponent]
+    });
     fixture = TestBed.createComponent(BaselineSurveyComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.spec.ts
+++ b/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.spec.ts
@@ -1,14 +1,37 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatDialogModule, MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { of } from 'rxjs';
 
 import { BaselineSurveyComponent } from './baseline-survey.component';
+import { BaselineSurveyService } from 'src/app/core/services/baseline-survey.service';
 
 describe('BaselineSurveyComponent', () => {
   let component: BaselineSurveyComponent;
   let fixture: ComponentFixture<BaselineSurveyComponent>;
+  let mockBaselineSurveyService: any;
+  let mockDialogRef: any;
 
   beforeEach(() => {
+    mockBaselineSurveyService = jasmine.createSpyObj('BaselineSurveyService', ['submitSurvey', 'remindLater']);
+    mockBaselineSurveyService.submitSurvey.and.returnValue(of({ success: true }));
+    mockBaselineSurveyService.remindLater.and.returnValue(of({ success: true }));
+
+    mockDialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+
     TestBed.configureTestingModule({
-      declarations: [BaselineSurveyComponent]
+      imports: [
+        ReactiveFormsModule,
+        MatDialogModule,
+        MatSnackBarModule
+      ],
+      declarations: [BaselineSurveyComponent],
+      providers: [
+        { provide: BaselineSurveyService, useValue: mockBaselineSurveyService },
+        { provide: MatDialogRef, useValue: mockDialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: { remindLaterCount: 0, isMandatory: false } }
+      ]
     });
     fixture = TestBed.createComponent(BaselineSurveyComponent);
     component = fixture.componentInstance;

--- a/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.ts
@@ -1,4 +1,3 @@
-
 import { Component, Inject } from '@angular/core';
 import {
   FormBuilder, FormGroup, FormArray, Validators,
@@ -16,32 +15,145 @@ import { BaselineSurveyService } from 'src/app/core/services/baseline-survey.ser
 export class BaselineSurveyComponent {
   surveyForm: FormGroup;
   submitting = false;
+  reminding = false;
+  submitted = false;
   error: string | null = null;
 
-  // Options
-  planOptions = ['Paper-based', 'Digital documents (Word/Google Docs/PowerPoint)'];
+  /** -1 = intro screen, 0..totalSteps-1 = question steps */
+  currentStep = -1;
+
+  // Order of form controls that make up each step of the wizard.
+  private stepControlNames: string[] = [
+    'plans',
+    'devices',
+    'weeklyLessonPlans',
+    'lessonPlanComponents',
+    'timePerLessonPlan',
+    'resourcesUsed',
+    'timeForAssessments',
+    'questionBalance',
+    'otherNotes'
+  ];
+
+  get totalSteps(): number {
+    return this.stepControlNames.length;
+  }
+
+  /** Used purely to *ngFor the tally track ticks */
+  get stepProgressArray(): number[] {
+    return Array.from({ length: this.totalSteps });
+  }
+
+  get isLastStep(): boolean {
+    return this.currentStep === this.totalSteps - 1;
+  }
+
+  get nextButtonLabel(): string {
+    return this.isLastStep ? 'Submit survey' : 'Next';
+  }
+
+  // Q1 – How do you currently prepare your lesson plans?
+  planOptions = [
+    'Paper-based (Notebook/Register)',
+    'Digital documents (Word, Google Docs, PowerPoint, etc.)',
+    'Other'
+  ];
+
+  // Q2 – Which devices do you use while preparing lesson plans?
   deviceOptions = [
     'School desktop/laptop/tablet',
     'Personal desktop/laptop/tablet',
     'Personal mobile phone',
-    'Not applicable'
+    "Another person's device (family/friend/colleague)",
+    'Books/Notes only (No digital device)',
+    'Other'
   ];
+
+  // Q3 – How many lesson plans per week?
   weeklyOptions = ['1', '2', '3', '4', 'More than 5'];
+
+  // Q4 – Which components do you include?
   componentOptions = [
     'Hands-on activities',
-    'Real-world examples or analogies',
+    'Real-world examples / Analogies',
     'Stories',
     'Videos',
-    'Others' // "Others" has input
+    'Classroom discussion',
+    'None of the above',
+    'Other'
   ];
-  timeOptions = ['30 minutes', '60 minutes', '90 minutes', 'Others'];//"Others" has input
+
+  // Q5 – Time per lesson plan (radio)
+  timePerLessonOptions = [
+    'Less than 15 minutes',
+    '15–30 minutes',
+    '30–60 minutes',
+    '60–90 minutes',
+    'More than 90 minutes',
+    'Other'
+  ];
+
+  // Q6 – Resources used
   resourceOptions = [
-    'Educational websites (Khan Academy)',
-    'Diksha',
+    'School textbooks',
+    'Other textbooks / Reference books',
+    'DIKSHA',
+    'Educational websites (Khan Academy etc.)',
     'YouTube',
-    'Others' // "Others" has input
+    'AI tools (ChatGPT, Shiksha Copilot, Gemini, etc.)',
+    'Search engines (Google, Bing, etc.)',
+    'Other'
   ];
-  assessOptions = ['30 minutes', '60 minutes', '90 minutes', 'Others']; //"Others" has input
+
+  // Q7 – Time for formative assessment (radio)
+  timeAssessmentOptions = [
+    'Less than 15 minutes',
+    '15–30 minutes',
+    '30–60 minutes',
+    '60–90 minutes',
+    'More than 90 minutes',
+    'Other'
+  ];
+
+  // Q8 – Question balance strategy (multi-select)
+  questionBalanceOptions = [
+    'I use my own experience',
+    'I refer to previous question papers',
+    'I discuss with colleagues',
+    'I follow a blueprint/guidelines',
+    'I do not specifically check this',
+    'Other'
+  ];
+
+  // Maps each checkbox-array control to its "Other" free-text control,
+  // so the text becomes required exactly when "Other" is checked.
+  private otherFieldMap: { [key: string]: string } = {
+    plans: 'plansOther',
+    devices: 'devicesOther',
+    lessonPlanComponents: 'lessonPlanComponentsOther',
+    resourcesUsed: 'resourcesUsedOther',
+    questionBalance: 'questionBalanceOther'
+  };
+
+  // Same idea, but for the radio-style questions handled via selectRadioValue().
+  private radioOtherFieldMap: { [key: string]: string } = {
+    timePerLessonPlan: 'timePerLessonPlanOther',
+    timeForAssessments: 'timeForAssessmentsOther'
+  };
+
+  // Checkbox-array controls where one option is exclusive of all the others
+  // (e.g. "None of the above" wipes out and disables every other choice).
+  private exclusiveOptionMap: { [key: string]: string } = {
+    lessonPlanComponents: 'None of the above'
+  };
+
+  get remindLaterCount(): number {
+    return this.data?.remindLaterCount ?? 0;
+  }
+
+  get isMandatory(): boolean {
+    return this.data?.isMandatory === true;
+  }
 
   constructor(
     private fb: FormBuilder,
@@ -51,20 +163,31 @@ export class BaselineSurveyComponent {
     @Inject(MAT_DIALOG_DATA) public data: any
   ) {
     this.surveyForm = this.fb.group({
+      // Q1
       plans: this.fb.array([], [Validators.required, this.minSelectedCheckboxes(1)]),
+      plansOther: [''],
+      // Q2
       devices: this.fb.array([], [Validators.required, this.minSelectedCheckboxes(1)]),
+      devicesOther: [''],
+      // Q3
       weeklyLessonPlans: ['', Validators.required],
+      // Q4
       lessonPlanComponents: this.fb.array([], [Validators.required, this.minSelectedCheckboxes(1)]),
+      lessonPlanComponentsOther: [''],
+      // Q5
       timePerLessonPlan: ['', Validators.required],
+      timePerLessonPlanOther: [''],
+      // Q6
       resourcesUsed: this.fb.array([], [Validators.required, this.minSelectedCheckboxes(1)]),
+      resourcesUsedOther: [''],
+      // Q7
       timeForAssessments: ['', Validators.required],
+      timeForAssessmentsOther: [''],
+      // Q8
+      questionBalance: this.fb.array([], [Validators.required, this.minSelectedCheckboxes(1)]),
+      questionBalanceOther: [''],
+      // Q9
       otherNotes: [''],
-
-      // NEW: "Others" free-text fields
-      otherLessonPlanComponent: [''],   // when "Others" is checked in components
-      otherResourceUsed: [''],          // when "Others" is checked in resources
-      otherTimePerLessonPlan: [''],     // when timePerLessonPlan = "Others"
-      otherTimeForAssessments: ['']     // when timeForAssessments = "Others"
     });
   }
 
@@ -79,8 +202,47 @@ export class BaselineSurveyComponent {
     };
   }
 
+  /** Turns the required validator on/off for a given "Other" text control. */
+  private updateOtherValidator(controlName: string, required: boolean): void {
+    const control = this.surveyForm.get(controlName);
+    if (!control) return;
+
+    if (required) {
+      control.setValidators([Validators.required]);
+    } else {
+      control.clearValidators();
+      control.setValue('');
+    }
+    control.updateValueAndValidity();
+  }
+
   toggleArray(controlName: string, value: string): void {
     const formArray = this.surveyForm.get(controlName) as FormArray;
+    const exclusiveOption = this.exclusiveOptionMap[controlName];
+
+    if (exclusiveOption) {
+      if (value === exclusiveOption) {
+        // Toggling "None of the above" itself: either select it alone, or clear it.
+        const alreadySelected = this.isChecked(controlName, exclusiveOption);
+        formArray.clear();
+        if (!alreadySelected) {
+          formArray.push(new FormControl(exclusiveOption));
+        }
+        const otherControlName = this.otherFieldMap[controlName];
+        if (otherControlName) {
+          this.updateOtherValidator(otherControlName, false);
+        }
+        formArray.updateValueAndValidity();
+        formArray.markAsTouched();
+        return;
+      }
+
+      // Selecting any other option should not coexist with "None of the above".
+      if (this.isOptionDisabled(controlName, value)) {
+        return; // guarded in the template too, but block here just in case
+      }
+    }
+
     const index = formArray.value.indexOf(value);
     if (index === -1) {
       formArray.push(new FormControl(value));
@@ -88,6 +250,12 @@ export class BaselineSurveyComponent {
       formArray.removeAt(index);
     }
     formArray.updateValueAndValidity();
+    formArray.markAsTouched();
+
+    const otherControlName = this.otherFieldMap[controlName];
+    if (otherControlName) {
+      this.updateOtherValidator(otherControlName, this.isChecked(controlName, 'Other'));
+    }
   }
 
   isChecked(controlName: string, value: string): boolean {
@@ -95,21 +263,95 @@ export class BaselineSurveyComponent {
     return formArray.value.includes(value);
   }
 
-  // NEW: convenience getters for showing "Others" inputs
-  get showOtherLessonComponent(): boolean {
-    return this.isChecked('lessonPlanComponents', 'Others');
+  /**
+   * True when `option` should be greyed out and unclickable because the
+   * control's exclusive option (e.g. "None of the above") is currently selected.
+   * "Other" is exempt — a teacher can still pick "None of the above" and
+   * additionally specify something via "Other".
+   */
+  isOptionDisabled(controlName: string, option: string): boolean {
+    const exclusiveOption = this.exclusiveOptionMap[controlName];
+    if (!exclusiveOption || option === exclusiveOption || option === 'Other') return false;
+    return this.isChecked(controlName, exclusiveOption);
   }
 
-  get showOtherResourceUsed(): boolean {
-    return this.isChecked('resourcesUsed', 'Others');
+  /** True when this control's exclusive option (e.g. "None of the above") is selected. */
+  isExclusiveOptionActive(controlName: string): boolean {
+    const exclusiveOption = this.exclusiveOptionMap[controlName];
+    if (!exclusiveOption) return false;
+    return this.isChecked(controlName, exclusiveOption);
   }
 
-  get showOtherTimePerLessonPlan(): boolean {
-    return this.surveyForm.get('timePerLessonPlan')?.value === 'Others';
+  /** Text explaining why the other options are locked, for tooltips/notes. */
+  exclusiveOptionMessage(controlName: string): string {
+    const exclusiveOption = this.exclusiveOptionMap[controlName];
+    return exclusiveOption
+      ? `Deselect "${exclusiveOption}" to choose other options, or use "Other" to add specifics.`
+      : '';
   }
 
-  get showOtherTimeForAssessments(): boolean {
-    return this.surveyForm.get('timeForAssessments')?.value === 'Others';
+  /** Sets a single-value (radio-style) control and marks it touched */
+  selectRadioValue(controlName: string, value: string): void {
+    const control = this.surveyForm.get(controlName);
+    control?.setValue(value);
+    control?.markAsTouched();
+
+    const otherControlName = this.radioOtherFieldMap[controlName];
+    if (otherControlName) {
+      this.updateOtherValidator(otherControlName, value === 'Other');
+    }
+  }
+
+  // "Other" visibility getters
+  get showPlansOther(): boolean { return this.isChecked('plans', 'Other'); }
+  get showDevicesOther(): boolean { return this.isChecked('devices', 'Other'); }
+  get showLessonComponentsOther(): boolean { return this.isChecked('lessonPlanComponents', 'Other'); }
+  get showTimePerLessonOther(): boolean { return this.surveyForm.get('timePerLessonPlan')?.value === 'Other'; }
+  get showResourcesOther(): boolean { return this.isChecked('resourcesUsed', 'Other'); }
+  get showTimeAssessmentsOther(): boolean { return this.surveyForm.get('timeForAssessments')?.value === 'Other'; }
+  get showQuestionBalanceOther(): boolean { return this.isChecked('questionBalance', 'Other'); }
+
+  /** Moves from the intro screen into question 1 */
+  startSurvey(): void {
+    this.currentStep = 0;
+  }
+
+  goNext(): void {
+    if (this.currentStep === -1) {
+      this.startSurvey();
+      return;
+    }
+
+    const controlName = this.stepControlNames[this.currentStep];
+    const control = controlName ? this.surveyForm.get(controlName) : null;
+
+    if (control && control.invalid) {
+      control.markAsTouched();
+      return;
+    }
+
+    // Block advancing if this step's "Other" text is required but still empty.
+    const otherControlName = this.otherFieldMap[controlName] || this.radioOtherFieldMap[controlName];
+    if (otherControlName) {
+      const otherControl = this.surveyForm.get(otherControlName);
+      if (otherControl && otherControl.invalid) {
+        otherControl.markAsTouched();
+        return;
+      }
+    }
+
+    if (this.isLastStep) {
+      this.onSubmit();
+      return;
+    }
+
+    this.currentStep++;
+  }
+
+  goBack(): void {
+    if (this.currentStep > 0) {
+      this.currentStep--;
+    }
   }
 
   onSubmit(): void {
@@ -122,31 +364,17 @@ export class BaselineSurveyComponent {
     this.submitting = true;
     this.error = null;
 
-    const formValue = this.surveyForm.value;
-
-    // OPTIONAL: if you want to merge "Others" text into arrays,
-    // uncomment these lines and adjust your API side if needed.
-
-    // if (formValue.otherLessonPlanComponent) {
-    //   formValue.lessonPlanComponents = formValue.lessonPlanComponents
-    //     .filter((v: string) => v !== 'Others')
-    //     .concat(`Others: ${formValue.otherLessonPlanComponent}`);
-    // }
-    // if (formValue.otherResourceUsed) {
-    //   formValue.resourcesUsed = formValue.resourcesUsed
-    //     .filter((v: string) => v !== 'Others')
-    //     .concat(`Others: ${formValue.otherResourceUsed}`);
-    // }
-
-    this.surveyService.submitSurvey(formValue).subscribe({
+    this.surveyService.submitSurvey(this.surveyForm.value).subscribe({
       next: (response) => {
         this.submitting = false;
         if (response.success) {
+          this.submitted = true;
           this.snackBar.open('Survey submitted successfully!', 'Close', {
             duration: 5000,
             panelClass: ['success-snackbar']
           });
-          this.dialogRef.close(true);
+          // brief pause so the "thank you" state is visible before the dialog closes
+          setTimeout(() => this.dialogRef.close(true), 1300);
         } else {
           this.error = response.message || 'Failed to submit survey. Please try again.';
         }
@@ -159,17 +387,19 @@ export class BaselineSurveyComponent {
     });
   }
 
-  onClose(): void {
-    if (this.data?.force) {
-      return;
-    }
-    if (this.surveyForm.dirty) {
-      if (confirm('You have unsaved changes. Are you sure you want to leave?')) {
-        this.dialogRef.close(false);
+  onRemindLater(): void {
+    if (this.isMandatory) return;
+    this.reminding = true;
+    this.surveyService.remindLater().subscribe({
+      next: () => {
+        this.reminding = false;
+        this.dialogRef.close('remind');
+      },
+      error: () => {
+        this.reminding = false;
+        this.dialogRef.close('remind');
       }
-    } else {
-      this.dialogRef.close(false);
-    }
+    });
   }
 
   private markTouched(group: FormGroup | FormArray) {

--- a/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.ts
@@ -148,7 +148,7 @@ export class BaselineSurveyComponent {
   };
 
   get remindLaterCount(): number {
-    return this.data?.remindLaterCount ?? 0;
+    return this.data.remindLaterCount;
   }
 
   get isMandatory(): boolean {
@@ -387,7 +387,9 @@ export class BaselineSurveyComponent {
     });
   }
 
-  readonly MAX_REMINDERS = 3;
+  get maxReminders(): number {
+    return this.data?.maxReminders ?? 3;
+  }
 
   onRemindLater(): void {
     if (this.isMandatory) return;

--- a/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.ts
+++ b/shiksha-website/shiksha-frontend/src/app/shared/components/baseline-survey/baseline-survey.component.ts
@@ -387,17 +387,25 @@ export class BaselineSurveyComponent {
     });
   }
 
+  readonly MAX_REMINDERS = 3;
+
   onRemindLater(): void {
     if (this.isMandatory) return;
     this.reminding = true;
+    this.error = null;
     this.surveyService.remindLater().subscribe({
-      next: () => {
+      next: (res) => {
         this.reminding = false;
-        this.dialogRef.close('remind');
+        if (res && res.success) {
+          this.dialogRef.close('remind');
+        } else {
+          this.error = 'Failed to postpone the survey. Please try again.';
+        }
       },
-      error: () => {
+      error: (err) => {
+        console.error('Error postponing survey:', err);
         this.reminding = false;
-        this.dialogRef.close('remind');
+        this.error = 'An error occurred while postponing. Please try again.';
       }
     });
   }


### PR DESCRIPTION
# Summary

This PR updates the **Baseline Survey** flow for the **2026 Academic Year**.

The implementation ensures that eligible teacher users receive the Baseline Survey immediately after a successful login without requiring a browser refresh. It also introduces reminder tracking, prevents survey bypass through navigation or dialog dismissal, enforces mandatory survey completion after the reminder limit is reached, and ensures that each user can submit the Baseline Survey only once per academic year.

---

# Backend Changes

- Added `BaselineSurveyReminder` model to track:
  - Reminder count
  - Mandatory survey status
  - Academic year-specific reminder information
- Updated `baselineSurvey.manager.js`
  - Enhanced survey completion logic.
  - Returns `remindLaterCount` and `isMandatory`.
  - Enforced **one Baseline Survey submission per user per academic year**.
- Updated `baselineSurvey.dao.js`
  - Added reminder lookup and persistence logic.
- Updated controller and routes
  - Added/updated `PATCH /api/baseline-surveys/remind-later`.
  - Increments reminder count.
  - Marks the survey as mandatory once the reminder limit is reached.
- Prevents duplicate survey submissions for the same academic year.
- Maintained backward compatibility with previous academic year survey records.

---

# Frontend Changes

## Services

### `baseline-survey.service.ts`
- Fixed stale survey completion caching (cache only when survey is completed).
- Added session-level survey state management.
- Added:
  - `dismissedInSession`
  - `resetSession()`
  - `setDismissed()`

### `baseline-survey-dialog.service.ts`
- Prevented multiple survey dialogs from opening simultaneously.
- Updated dialog close handling for survey completion and reminder actions.
- Enabled `disableClose: true` to prevent closing the survey using the backdrop or **Esc** key.

---

## Guards

### `baseline-survey.guard.ts`
- Added session dismissal check using `isDismissed()`.
- Prevented the survey from reopening within the same session after selecting **Remind Me Later**.
- Updated role eligibility logic.
- Excluded Admin, Coordinator, Trainer, Manager, and Super Admin users from the survey flow.

---

## Components

### `sign-in.component.ts`
- Triggered the Baseline Survey immediately after successful login.
- Removed the dependency on browser refresh.
- Reset survey session state for every new login.

### `app.component.ts`
- Removed the legacy application-level survey trigger.
- Survey flow is now managed entirely by `BaselineSurveyGuard`.

### Baseline Survey Component
- Updated survey dialog UI.
- Added remaining reminder count display.
- Added mandatory survey messaging once the reminder limit is reached.
- Improved overall survey flow and user experience.

---

# Testing

| Scenario | Status |
|----------|--------|
| First-time login displays the Baseline Survey immediately (no browser refresh required) | ✅ Pass |
| "Remind Me Later" hides the survey for the current session | ✅ Pass |
| Survey does not reopen during the same session after selecting "Remind Me Later" | ✅ Pass |
| Survey appears again after a new session (browser refresh/re-login) | ✅ Pass |
| Reminder count increments correctly | ✅ Pass |
| Survey becomes mandatory after the reminder limit is reached | ✅ Pass |
| "Remind Me Later" option is removed once the survey becomes mandatory | ✅ Pass |
| Clicking outside the dialog (backdrop) does not dismiss the survey | ✅ Pass |
| Pressing the Esc key does not dismiss the survey | ✅ Pass |
| Users cannot bypass the survey through sidebar or page navigation | ✅ Pass |
| Admin users (including dual-role users) are excluded from the survey flow | ✅ Pass |
| Eligible Standard/Power teacher users receive the survey | ✅ Pass |
| Survey submission completes successfully | ✅ Pass |
| Success confirmation dialog is displayed after submission | ✅ Pass |
| Duplicate survey submission in the same academic year is blocked | ✅ Pass |
| Completed users are not prompted again for the current academic year | ✅ Pass |

---

# Screenshots

### 1. Baseline Survey displayed immediately after successful login

- Survey is triggered immediately after login without requiring a browser refresh.
- Displays the remaining reminder count before the survey becomes mandatory.

<img width="1918" height="937" alt="1st_login_survey" src="https://github.com/user-attachments/assets/770cd712-79b7-4c33-a9b8-e51fbf6e5ce7" />



---

### 2. Mandatory Survey after reminder limit

- Once the reminder limit is reached, the **"Remind Me Later"** option is removed.
- Users are required to complete the survey before continuing.

<img width="1918" height="937" alt="mandatary_survey" src="https://github.com/user-attachments/assets/b89f9a91-1fc8-4461-8484-7f873b658cd0" />


---

### 3. Survey enforcement across application navigation

- The Baseline Survey remains active while navigating between application modules.
- Users cannot bypass the survey by using the sidebar or page navigation.

<img width="1918" height="937" alt="2st_login_survey" src="https://github.com/user-attachments/assets/4338b387-435a-47b3-9300-6168532a9ae2" />


---

### 4. Successful survey submission

- Displays a confirmation dialog after the survey is submitted successfully.
- Survey is marked as completed and will not be shown again for the current academic year.

<img width="1918" height="937" alt="survey_submit" src="https://github.com/user-attachments/assets/0099fc8f-c2b2-4539-b0dc-8961586157ef" />


---

# Checklist

- [x] Backend implementation completed
- [x] Frontend implementation completed
- [x] Local testing completed
- [x] Verified first-time login flow
- [x] Verified "Remind Me Later" flow
- [x] Verified mandatory survey flow
- [x] Verified survey cannot be bypassed through navigation
- [x] Verified duplicate submissions are blocked for the same academic year
- [x] Verified successful survey submission
- [x] Screenshots attached

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned the baseline survey as a multi-step wizard (Q1–Q9) with progress tracking and improved “Other” handling, including a new question-balance step.
  * Added server-backed “Remind me later” with capped reminder counts and mandatory follow-up once the limit is reached (rate-limited).
* **Bug Fixes**
  * Improved duplicate submission handling and clearer conflict responses.
  * Added stronger validation and better unauthorized/error handling for survey actions.
* **Other**
  * Updated baseline prompting to respect dismissal within the current session and align post-login routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->