### PR TITLE
fix(ci): restore GitHub Actions Pages deployment for frontend

### DIFF
--- a/.github/workflows/cicd-frontend.yaml
+++ b/.github/workflows/cicd-frontend.yaml
@@ -50,8 +50,11 @@ on:
         description: "GitHub Pages deployment URL (empty when not deployed)"
         value: ${{ jobs.build.outputs.page_url }}
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -65,10 +68,10 @@ jobs:
 
     environment:
       name: ${{ inputs.deploy_target != '' && inputs.deploy_name || '' }}
-      url: ${{ steps.ctx.outputs.page_url || steps.deploy-azure-swa.outputs.static_web_app_url || '' }}
+      url: ${{ steps.deployment.outputs.page_url || steps.deploy-azure-swa.outputs.static_web_app_url || '' }}
 
     outputs:
-      page_url: ${{ steps.ctx.outputs.page_url || steps.deploy-azure-swa.outputs.static_web_app_url }}
+      page_url: ${{ steps.deployment.outputs.page_url || steps.deploy-azure-swa.outputs.static_web_app_url }}
 
     env:
       BACKEND_URL: ${{ inputs.api_url }}
@@ -89,16 +92,6 @@ jobs:
           cache: npm
           cache-dependency-path: shiksha-website/shiksha-frontend/package-lock.json
 
-      # peaceiris/actions-gh-pages doesn't emit a page_url output like
-      # actions/deploy-pages does, so we build it ourselves.
-      - name: Compute Pages context
-        if: inputs.deploy_target == 'github-pages'
-        id: ctx
-        run: |
-          bh="/${{ github.event.repository.name }}/"
-          echo "base_href=$bh" >> "$GITHUB_OUTPUT"
-          echo "page_url=https://${{ github.repository_owner }}.github.io$bh" >> "$GITHUB_OUTPUT"
-
       - name: Build Angular app
         working-directory: shiksha-website/shiksha-frontend
         run: |
@@ -113,19 +106,23 @@ jobs:
             -exec sed -i "s|your_superset_mobile_dashboard_uuid|${SUPERSET_MOBILE_DASHBOARD_UUID}|g" {} \;
 
           npm ci
-          if [ "${{ inputs.deploy_target }}" == "github-pages" ]; then
-            npm run build -- --configuration ${{ inputs.environment }} \
-              --base-href "${{ steps.ctx.outputs.base_href }}"
-          else
-            npm run build -- --configuration ${{ inputs.environment }}
-          fi
+          npm run build -- --configuration ${{ inputs.environment }} \
+            ${{ inputs.deploy_target == 'github-pages' && '--base-href /Shiksha-Copilot/' || '' }}
 
-      - name: Deploy to GitHub Pages (gh-pages branch)
+      - name: Setup Pages
         if: inputs.deploy_target == 'github-pages'
-        uses: peaceiris/actions-gh-pages@v4
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        if: inputs.deploy_target == 'github-pages'
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: shiksha-website/shiksha-frontend/dist/shiksha-frontend
+          path: shiksha-website/shiksha-frontend/dist/shiksha-frontend
+
+      - name: Deploy to GitHub Pages
+        if: inputs.deploy_target == 'github-pages'
+        id: deployment
+        uses: actions/deploy-pages@v4
 
       - name: Deploy to Azure Static Web App
         id: deploy-azure-swa


### PR DESCRIPTION
PR #101 replaced actions/configure-pages + upload-pages-artifact + deploy-pages with peaceiris/actions-gh-pages, which pushes to a gh-pages branch. The repo's Pages source is 'GitHub Actions', so the push published nothing and the frontend deploy/downstream smoke and accessibility jobs failed on a4i/staging.

Restore the Actions-based Pages deployment (and the pages/id-token permissions it needs), including the steps.deployment.outputs.page_url that the environment URL and job outputs consume.